### PR TITLE
Exclude matches from ChangeIn pattern match

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,4 @@ e2e: build
 	ruby test/e2e/change_in_all_possible_locations.rb
 	ruby test/e2e/change_in_relative_paths.rb
 	ruby test/e2e/change_in_glob.rb
+	ruby test/e2e/change_in_excluded_paths.rb

--- a/pkg/pipelines/changein.go
+++ b/pkg/pipelines/changein.go
@@ -10,8 +10,9 @@ import (
 )
 
 type ChangeInFunctionParams struct {
-	PathPatterns  []string
-	DefaultBranch string
+	PathPatterns         []string
+	ExcludedPathPatterns []string
+	DefaultBranch        string
 }
 
 type ChangeInFunction struct {
@@ -35,21 +36,33 @@ func (f *ChangeInFunction) DefaultBranchExists() bool {
 func (f *ChangeInFunction) Eval() bool {
 	f.LoadDiffList()
 
-	for _, pathPattern := range f.Params.PathPatterns {
-		if len(pathPattern) == 0 {
-			continue
-		}
-
-		for _, diffLine := range f.diffList {
-			if changeInPatternMatch(diffLine, pathPattern, f.Workdir) {
-				fmt.Printf("Change In: Matched '%s' with '%s' in the git diff list\n", pathPattern, diffLine)
-
-				return true
-			}
+	for _, diffLine := range f.diffList {
+		if f.MatchesPattern(diffLine) && !f.Excluded(diffLine) {
+			return true
 		}
 	}
 
 	return false
+}
+
+func (f *ChangeInFunction) MatchesPattern(diffLine string) bool {
+	for _, pathPattern := range f.Params.PathPatterns {
+		if changeInPatternMatch(diffLine, pathPattern, f.Workdir) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (f *ChangeInFunction) Excluded(diffLine string) bool {
+	for _, pathPattern := range f.Params.ExcludedPathPatterns {
+		if changeInPatternMatch(diffLine, pathPattern, f.Workdir) {
+			return false
+		}
+	}
+
+	return true
 }
 
 func changeInPatternMatch(diffLine string, pattern string, workDir string) bool {

--- a/pkg/pipelines/changein.go
+++ b/pkg/pipelines/changein.go
@@ -37,6 +37,8 @@ func (f *ChangeInFunction) Eval() bool {
 	f.LoadDiffList()
 
 	for _, diffLine := range f.diffList {
+		fmt.Printf("  Checking diff line '%s'\n", diffLine)
+
 		if f.MatchesPattern(diffLine) && !f.Excluded(diffLine) {
 			return true
 		}
@@ -48,6 +50,7 @@ func (f *ChangeInFunction) Eval() bool {
 func (f *ChangeInFunction) MatchesPattern(diffLine string) bool {
 	for _, pathPattern := range f.Params.PathPatterns {
 		if changeInPatternMatch(diffLine, pathPattern, f.Workdir) {
+			fmt.Printf("    Matched pattern %s\n", pathPattern)
 			return true
 		}
 	}
@@ -58,11 +61,12 @@ func (f *ChangeInFunction) MatchesPattern(diffLine string) bool {
 func (f *ChangeInFunction) Excluded(diffLine string) bool {
 	for _, pathPattern := range f.Params.ExcludedPathPatterns {
 		if changeInPatternMatch(diffLine, pathPattern, f.Workdir) {
-			return false
+			fmt.Printf("    Excluded with pattern %s\n", pathPattern)
+			return true
 		}
 	}
 
-	return true
+	return false
 }
 
 func changeInPatternMatch(diffLine string, pattern string, workDir string) bool {

--- a/pkg/pipelines/when.go
+++ b/pkg/pipelines/when.go
@@ -55,11 +55,8 @@ func EvaluateChangeIns(p *gabs.Container, yamlPath string) error {
 	whenList := ListWhenConditions(p)
 
 	for _, w := range whenList.List {
-		fmt.Println("Processing when expression:")
-		fmt.Println(w.Expression)
-
-		fmt.Println("From:")
-		fmt.Println(w.Path)
+		fmt.Printf("Processing when expression %s\n", w.Expression)
+		fmt.Printf("  From: %v\n", w.Path)
 
 		bytes, err := exec.Command("when", "list-inputs", w.Expression).Output()
 		if err != nil {
@@ -67,8 +64,7 @@ func EvaluateChangeIns(p *gabs.Container, yamlPath string) error {
 			panic(err)
 		}
 
-		fmt.Println("Inputs needed for this expression:")
-		fmt.Println(string(bytes))
+		fmt.Printf("  Inputs needed: %s\n", string(bytes))
 
 		neededInputs, err := gabs.ParseJSON(bytes)
 		if err != nil {
@@ -115,7 +111,7 @@ func EvaluateChangeIns(p *gabs.Container, yamlPath string) error {
 				}
 			}
 
-			fmt.Println("Checking if branch exists.")
+			fmt.Println("  Checking if branch exists.")
 			if !fun.DefaultBranchExists() {
 				logs.Log(logs.ErrorChangeInMissingBranch{
 					Message: "Unknown git reference 'random'.",
@@ -124,7 +120,7 @@ func EvaluateChangeIns(p *gabs.Container, yamlPath string) error {
 					},
 				})
 
-				return fmt.Errorf("Branch '%s' does not exists.", fun.Params.DefaultBranch)
+				return fmt.Errorf("  Branch '%s' does not exists.", fun.Params.DefaultBranch)
 			}
 
 			hasChanges := fun.Eval()
@@ -138,12 +134,11 @@ func EvaluateChangeIns(p *gabs.Container, yamlPath string) error {
 			inputs.Functions = append(inputs.Functions, funInput)
 		}
 
-		fmt.Println(inputs)
 		inputBytes, err := json.Marshal(inputs)
 		if err != nil {
 			panic(err)
 		}
-		fmt.Println(string(inputBytes))
+		fmt.Printf("  Providing inputs: %s\n", string(inputBytes))
 
 		err = ioutil.WriteFile("/tmp/inputs.json", inputBytes, 0644)
 		if err != nil {
@@ -155,8 +150,7 @@ func EvaluateChangeIns(p *gabs.Container, yamlPath string) error {
 			panic(err)
 		}
 
-		fmt.Println("Result:")
-		fmt.Println(string(bytes))
+		fmt.Printf("  Reduced When Expression: %s\n", string(bytes))
 
 		expr := strings.TrimSpace(string(bytes))
 

--- a/pkg/pipelines/when.go
+++ b/pkg/pipelines/when.go
@@ -109,6 +109,12 @@ func EvaluateChangeIns(p *gabs.Container, yamlPath string) error {
 				fun.Params.PathPatterns = append(fun.Params.PathPatterns, input.Search("params", "0").Data().(string))
 			}
 
+			if _, ok := input.Search("params", "1", "exclude").Data().([]interface{}); ok {
+				for _, p := range input.Search("params", "1", "exclude").Children() {
+					fun.Params.ExcludedPathPatterns = append(fun.Params.ExcludedPathPatterns, p.Data().(string))
+				}
+			}
+
 			fmt.Println("Checking if branch exists.")
 			if !fun.DefaultBranchExists() {
 				logs.Log(logs.ErrorChangeInMissingBranch{

--- a/test/e2e/change_in_excluded_paths.rb
+++ b/test/e2e/change_in_excluded_paths.rb
@@ -63,11 +63,11 @@ agent:
 
 blocks:
   - name: Client
-    skip:
+    run:
       when: "change_in('/client')"
 
   - name: Backend
-    skip:
+    run:
       when: "change_in('/', {exclude: ['/client']})"
 }
 
@@ -111,11 +111,11 @@ agent:
 
 blocks:
   - name: Client
-    skip:
+    run:
       when: "true"
 
   - name: Backend
-    skip:
+    run:
       when: "false"
 }))
 
@@ -150,11 +150,11 @@ agent:
 
 blocks:
   - name: Client
-    skip:
+    run:
       when: "false"
 
   - name: Backend
-    skip:
+    run:
       when: "true"
 }))
 
@@ -190,10 +190,10 @@ agent:
 
 blocks:
   - name: Client
-    skip:
+    run:
       when: "true"
 
   - name: Backend
-    skip:
+    run:
       when: "true"
 }))

--- a/test/e2e/change_in_excluded_paths.rb
+++ b/test/e2e/change_in_excluded_paths.rb
@@ -119,80 +119,80 @@ blocks:
       when: "false"
 }))
 
-##
-## Testing out the scenario where only the backend changed.
-##
-#system %{
-#  cd /tmp/test-repo
-#  git checkout master
-#  git checkout -b backend-changes
+#
+# Testing out the scenario where only the backend changed.
+#
+system %{
+  cd /tmp/test-repo
+  git checkout master
+  git checkout -b backend-changes
 
-#  echo "hello hello" > config.txt
+  echo "hello hello" > config.txt
 
-#  git add . && git commit -m "Change things in the backend"
-#}
+  git add . && git commit -m "Change things in the backend"
+}
 
-#system(%{
-#  rm -f /tmp/output.yml
-#  cd /tmp/test-repo
+system(%{
+  rm -f /tmp/output.yml
+  cd /tmp/test-repo
 
-#  #{spc} evaluate change-in --input .semaphore/semaphore.yml --output /tmp/output.yml --logs /tmp/logs.yml
-#})
+  #{spc} evaluate change-in --input .semaphore/semaphore.yml --output /tmp/output.yml --logs /tmp/logs.yml
+})
 
-#output = YAML.load_file('/tmp/output.yml')
+output = YAML.load_file('/tmp/output.yml')
 
-#assert_eq(output, YAML.load(%{
-#version: v1.0
-#name: Test
-#agent:
-#  machine:
-#    type: e1-standard-2
+assert_eq(output, YAML.load(%{
+version: v1.0
+name: Test
+agent:
+  machine:
+    type: e1-standard-2
 
-#blocks:
-#  - name: Client
-#    skip:
-#      when: "false"
+blocks:
+  - name: Client
+    skip:
+      when: "false"
 
-#  - name: Backend
-#    skip:
-#      when: "true"
-#}))
+  - name: Backend
+    skip:
+      when: "true"
+}))
 
-##
-## Testing out the scenario where both and client have changes.
-##
-#system %{
-#  cd /tmp/test-repo
-#  git checkout master
-#  git checkout -b changes-in-both-places
+#
+# Testing out the scenario where both and client have changes.
+#
+system %{
+  cd /tmp/test-repo
+  git checkout master
+  git checkout -b changes-in-both-places
 
-#  echo "hello hello" > config.txt
+  echo "hello hello" > config.txt
 
-#  git add . && git commit -m "Change things in the backend"
-#}
+  git add . && git commit -m "Change things in the backend"
+}
 
-#system(%{
-#  rm -f /tmp/output.yml
-#  cd /tmp/test-repo
+system(%{
+  rm -f /tmp/output.yml
+  cd /tmp/test-repo
 
-#  #{spc} evaluate change-in --input .semaphore/semaphore.yml --output /tmp/output.yml --logs /tmp/logs.yml
-#})
+  #{spc} evaluate change-in --input .semaphore/semaphore.yml --output /tmp/output.yml --logs /tmp/logs.yml
+})
 
-#output = YAML.load_file('/tmp/output.yml')
+output = YAML.load_file('/tmp/output.yml')
 
-#assert_eq(output, YAML.load(%{
-#version: v1.0
-#name: Test
-#agent:
-#  machine:
-#    type: e1-standard-2
+assert_eq(output, YAML.load(%{
+version: v1.0
+name: Test
+agent:
+  machine:
+    type: e1-standard-2
 
-#blocks:
-#  - name: Client
-#    skip:
-#      when: "true"
+blocks:
+  - name: Client
+    skip:
+      when: "true"
 
-#  - name: Backend
-#    skip:
-#      when: "true"
-#}))
+  - name: Backend
+    skip:
+      when: "true"
+}))

--- a/test/e2e/change_in_excluded_paths.rb
+++ b/test/e2e/change_in_excluded_paths.rb
@@ -1,0 +1,198 @@
+# rubocop:disable all
+
+require_relative "../e2e"
+require 'yaml'
+
+#
+# The exclude option lets us to define paths that are not included in the
+# change_in set. An situation where this is useful is repository that has:
+#
+# - A main project in the root of the repository, for example a Rails project
+# - A sub-project called /client
+#
+# In this scenario, we want to have two blocks in the pipeline, one for the
+# main application, and one for the client.
+#
+# These blocks need to satisfy the following:
+#
+# - If there are changes in the root and in the /client directory => Run both blocks.
+# - If there are changes only outside of the /client directory => Run only the backend tests.
+# - If there are changes in the /client directory => Run the frontend tests.
+#
+# For the Client block, it is simple to construct such a rule.
+#
+#   change_in('/client')
+#
+# But for the backend, it is trickier. We want the block to run if there are any
+# changes in the repository, except if those changes are comming from the client
+# directory. To codify this exlusion, the exclude list can be used:
+#
+#   change_in('/', {exclude: ['/client']})
+#
+
+#
+# Prepare a repository with the following branches:
+#
+#  - master
+#  - client-changes             (has changes only in the client dir)
+#  - backend-change             (has changes only in the backend)
+#  - changes-in-both-places     (has changes in two places)
+#
+# The dev branch will have change only
+#
+system %{
+  rm -f /tmp/output.yml
+  rm -rf /tmp/test-repo
+  mkdir -p /tmp/test-repo
+  cd /tmp/test-repo
+  git init
+
+  # master branch
+  mkdir client .semaphore
+
+  echo "hello" > client/app.js
+  echo "hello" > config.txt
+}
+
+pipeline = %{
+version: v1.0
+name: Test
+agent:
+  machine:
+    type: e1-standard-2
+
+blocks:
+  - name: Client
+    skip:
+      when: "change_in('/client')"
+
+  - name: Backend
+    skip:
+      when: "change_in('/', {exclude: ['/client']})"
+}
+
+File.write('/tmp/test-repo/.semaphore/semaphore.yml', pipeline)
+
+system %{
+  cd /tmp/test-repo
+  git add .
+  git commit -m "Add semaphore pipeline"
+}
+
+#
+# Testing out the scenario where only the client changed.
+#
+system %{
+  cd /tmp/test-repo
+  git checkout master
+  git checkout -b client-changes
+
+  echo "hello hello" > client/app.js
+
+  git add . && git commit -m "Change things in the client"
+}
+
+
+system(%{
+  rm -f /tmp/output.yml
+  cd /tmp/test-repo
+
+  #{spc} evaluate change-in --input .semaphore/semaphore.yml --output /tmp/output.yml --logs /tmp/logs.yml
+})
+
+output = YAML.load_file('/tmp/output.yml')
+
+assert_eq(output, YAML.load(%{
+version: v1.0
+name: Test
+agent:
+  machine:
+    type: e1-standard-2
+
+blocks:
+  - name: Client
+    skip:
+      when: "true"
+
+  - name: Backend
+    skip:
+      when: "false"
+}))
+
+##
+## Testing out the scenario where only the backend changed.
+##
+#system %{
+#  cd /tmp/test-repo
+#  git checkout master
+#  git checkout -b backend-changes
+
+#  echo "hello hello" > config.txt
+
+#  git add . && git commit -m "Change things in the backend"
+#}
+
+#system(%{
+#  rm -f /tmp/output.yml
+#  cd /tmp/test-repo
+
+#  #{spc} evaluate change-in --input .semaphore/semaphore.yml --output /tmp/output.yml --logs /tmp/logs.yml
+#})
+
+#output = YAML.load_file('/tmp/output.yml')
+
+#assert_eq(output, YAML.load(%{
+#version: v1.0
+#name: Test
+#agent:
+#  machine:
+#    type: e1-standard-2
+
+#blocks:
+#  - name: Client
+#    skip:
+#      when: "false"
+
+#  - name: Backend
+#    skip:
+#      when: "true"
+#}))
+
+##
+## Testing out the scenario where both and client have changes.
+##
+#system %{
+#  cd /tmp/test-repo
+#  git checkout master
+#  git checkout -b changes-in-both-places
+
+#  echo "hello hello" > config.txt
+
+#  git add . && git commit -m "Change things in the backend"
+#}
+
+#system(%{
+#  rm -f /tmp/output.yml
+#  cd /tmp/test-repo
+
+#  #{spc} evaluate change-in --input .semaphore/semaphore.yml --output /tmp/output.yml --logs /tmp/logs.yml
+#})
+
+#output = YAML.load_file('/tmp/output.yml')
+
+#assert_eq(output, YAML.load(%{
+#version: v1.0
+#name: Test
+#agent:
+#  machine:
+#    type: e1-standard-2
+
+#blocks:
+#  - name: Client
+#    skip:
+#      when: "true"
+
+#  - name: Backend
+#    skip:
+#      when: "true"
+#}))

--- a/test/e2e/change_in_excluded_paths.rb
+++ b/test/e2e/change_in_excluded_paths.rb
@@ -166,6 +166,7 @@ system %{
   git checkout master
   git checkout -b changes-in-both-places
 
+  echo "hello hello" > client/app.js
   echo "hello hello" > config.txt
 
   git add . && git commit -m "Change things in the backend"


### PR DESCRIPTION
Related to https://github.com/semaphoreci/semaphore/issues/63.

---

The exclude option lets us to define paths that are not included in the
change_in set. A situation where this is useful is a repository that has:

- The main project in the root of the repository, for example, a Rails project
- A sub-project called in the /client directory that has a JS application

In this scenario, we want to have two blocks in the pipeline, one for the
main application, and one for the client.

These blocks need to satisfy the following:

- If there are changes in the root and in the /client directory => Run both blocks.
- If there are changes only outside of the /client directory => Run only the backend tests.
- If there are changes in the /client directory => Run the frontend tests.

For the Client block, it is simple to construct such a rule.

```
change_in('/client')
```

But for the backend, it is trickier. We want the block to run if there are any
changes in the repository, except if those changes are coming from the client
directory. To codify this exclusion, the exclude list can be used:

```
change_in('/', {exclude: ['/client']})
```

A full Pipeline YAML would look like this:

``` yaml
version: v1.0
name: Test
agent:
  machine:
    type: e1-standard-2

blocks:
  - name: Client
    skip:
      when: "change_in('/client')"

  - name: Backend
    skip:
      when: "change_in('/', {exclude: ['/client']})"
```
