### PR TITLE
Pipeline tracking in promotions

### DIFF
--- a/pkg/pipelines/model.go
+++ b/pkg/pipelines/model.go
@@ -30,7 +30,7 @@ func (p *Pipeline) EvaluateChangeIns(yamlPath string) error {
 				continue
 			}
 
-			fun, err := when.NewChangeInFunctionFromWhenInputList(input, yamlPath)
+			fun, err := when.NewChangeInFunctionFromWhenInputList(&w, input, yamlPath)
 			if err != nil {
 				panic(err)
 			}

--- a/pkg/when/changein.go
+++ b/pkg/when/changein.go
@@ -27,7 +27,7 @@ type ChangeInFunction struct {
 	diffList []string
 }
 
-func NewChangeInFunctionFromWhenInputList(input *gabs.Container, yamlPath string) (*ChangeInFunction, error) {
+func NewChangeInFunctionFromWhenInputList(when *WhenExpression, input *gabs.Container, yamlPath string) (*ChangeInFunction, error) {
 	params := ChangeInFunctionParams{
 		PathPatterns:         []string{},
 		ExcludedPathPatterns: []string{},
@@ -67,6 +67,12 @@ func NewChangeInFunctionFromWhenInputList(input *gabs.Container, yamlPath string
 			params.TrackPipelineFile = false
 		default:
 			return nil, fmt.Errorf("Unknown value type pipeline_file in change_in expression.")
+		}
+	} else {
+		if when.Path[0] == "promotions" {
+			params.TrackPipelineFile = false
+		} else {
+			params.TrackPipelineFile = true
 		}
 	}
 

--- a/test/e2e/change_in_pipeline_file_tracking.rb
+++ b/test/e2e/change_in_pipeline_file_tracking.rb
@@ -4,6 +4,17 @@ require_relative "../e2e"
 require 'yaml'
 
 #
+# By default, when a Pipeline YAML file is changed, every block is executed.
+# The reasoning is that if you have changed the YAML file, conditions have
+# changed and it is better to execute every block.
+#
+# The value of the pipeline_file is by default 'track' for blocks, queues,
+# auto_cancel, and fast_fail.
+#
+# However, for promotions, the default value is 'ignore'.
+#
+
+#
 # Prepare a repository with two branches, master and dev.
 #
 system %{
@@ -52,6 +63,19 @@ blocks:
         - name: Hello
           commands:
             - echo "Hello World"
+
+promotions:
+  - name: P1
+    auto_promote:
+      when: "change_in('/lib')"
+
+  - name: P2
+    auto_promote:
+      when: "change_in('/lib', {pipeline_file: 'ignore'})"
+
+  - name: P3
+    auto_promote:
+      when: "change_in('/lib', {pipeline_file: 'track'})"
 })
 
 system %{
@@ -117,4 +141,17 @@ blocks:
         - name: Hello
           commands:
             - echo "Hello World"
+
+promotions:
+  - name: P1
+    auto_promote:
+      when: "false"
+
+  - name: P2
+    auto_promote:
+      when: "false"
+
+  - name: P3
+    auto_promote:
+      when: "true"
 }))


### PR DESCRIPTION
In promotions, the default value is not `track`. It is `ignore` instead.