### PR TITLE
Simplify the cmd directory

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -1,20 +1,9 @@
 package main
 
 import (
-	"fmt"
-	"os"
-
-	"github.com/spf13/cobra"
+	cli "github.com/semaphoreci/spc/pkg/cli"
 )
 
-var rootCmd = &cobra.Command{
-	Use:   "spc",
-	Short: "Semaphore 2.0 Pipeline Compiler",
-}
-
 func main() {
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
+	cli.Execute()
 }

--- a/pkg/cli/evaluate.go
+++ b/pkg/cli/evaluate.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"io/ioutil"

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -1,0 +1,20 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "spc",
+	Short: "Semaphore 2.0 Pipeline Compiler",
+}
+
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/pkg/cli/util.go
+++ b/pkg/cli/util.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"fmt"


### PR DESCRIPTION
By default, goreleaser only takes the single `main.go` and ignores everything else in the `cmd/cli` directory.

I could handle this in two ways:
- Figure out how to configure goreleaser ina different way
- Move the CLI interface in PKG

Moving to PKG is simple, and it might also be the better of the two options.