### PR TITLE
Fetch branches before running ChangeIn evaluation

### DIFF
--- a/pkg/cli/evaluate.go
+++ b/pkg/cli/evaluate.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	logs "github.com/semaphoreci/spc/pkg/logs"
+	when "github.com/semaphoreci/spc/pkg/when"
 )
 
 var evaluateCmd = &cobra.Command{
@@ -21,6 +23,14 @@ var evaluateChangeInCmd = &cobra.Command{
 		input := fetchRequiredStringFlag(cmd, "input")
 		output := fetchRequiredStringFlag(cmd, "output")
 		logsPath := fetchRequiredStringFlag(cmd, "logs")
+
+		if !when.IsInstalled() {
+			fmt.Println("Error: Con't find the 'when' expression parser binary")
+			fmt.Println()
+			fmt.Println("Is it installed and available in $PATH?")
+
+			os.Exit(1)
+		}
 
 		logs.Open(logsPath)
 		logs.SetCurrentPipelineFilePath(input)

--- a/pkg/cli/evaluate.go
+++ b/pkg/cli/evaluate.go
@@ -36,25 +36,31 @@ var evaluateChangeInCmd = &cobra.Command{
 		logs.SetCurrentPipelineFilePath(input)
 
 		ppl, err := pipelines.LoadFromYaml(input)
-		if err != nil {
-			panic(err)
-		}
+		check(err)
 
 		err = ppl.EvaluateChangeIns(input)
-		if err != nil {
-			os.Exit(1)
-		}
+		check(err)
 
 		yamlPpl, err := ppl.ToYAML()
-		if err != nil {
-			panic(err)
-		}
+		check(err)
 
 		err = ioutil.WriteFile(output, yamlPpl, 0644)
-		if err != nil {
-			panic(err)
-		}
+		check(err)
 	},
+}
+
+func check(err error) {
+	if err == nil {
+		return
+	}
+
+	fmt.Println(err)
+
+	if _, ok := err.(*logs.ErrorChangeInMissingBranch); ok {
+		os.Exit(1)
+	}
+
+	panic(err)
 }
 
 func init() {

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -1,0 +1,16 @@
+package git
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+func Fetch(name string) ([]byte, error) {
+	fmt.Printf("Fetching branch from remote: '%s'\n", name)
+
+	flags := []string{"fetch", "origin", fmt.Sprintf("+refs/heads/%s:refs/heads/%s", name, name)}
+	fmt.Printf("Running git %s\n", strings.Join(flags, " "))
+
+	return exec.Command("git", flags...).CombinedOutput()
+}

--- a/pkg/logs/error_invalid_change_in.go
+++ b/pkg/logs/error_invalid_change_in.go
@@ -9,3 +9,7 @@ type ErrorChangeInMissingBranch struct {
 	Message  string   `json:"message"`
 	Location Location `json:"location"`
 }
+
+func (e *ErrorChangeInMissingBranch) Error() string {
+	return e.Message
+}

--- a/pkg/pipelines/model.go
+++ b/pkg/pipelines/model.go
@@ -32,12 +32,12 @@ func (p *Pipeline) EvaluateChangeIns(yamlPath string) error {
 
 			fun, err := when.ParseChangeIn(&w, input, yamlPath)
 			if err != nil {
-				panic(err)
+				return err
 			}
 
 			hasChanges, err := fun.Eval()
 			if err != nil {
-				panic(err)
+				return err
 			}
 
 			funInput := when.FunctionInput{
@@ -51,7 +51,7 @@ func (p *Pipeline) EvaluateChangeIns(yamlPath string) error {
 
 		err = w.Reduce(inputs)
 		if err != nil {
-			panic(err)
+			return err
 		}
 
 		fmt.Printf("  Reduced When Expression: %s\n", w.Expression)

--- a/pkg/pipelines/model.go
+++ b/pkg/pipelines/model.go
@@ -7,7 +7,6 @@ import (
 
 	gabs "github.com/Jeffail/gabs/v2"
 	"github.com/ghodss/yaml"
-	logs "github.com/semaphoreci/spc/pkg/logs"
 	when "github.com/semaphoreci/spc/pkg/when"
 )
 
@@ -36,19 +35,10 @@ func (p *Pipeline) EvaluateChangeIns(yamlPath string) error {
 				panic(err)
 			}
 
-			fmt.Println("  Checking if branch exists.")
-			if !fun.DefaultBranchExists() {
-				logs.Log(logs.ErrorChangeInMissingBranch{
-					Message: "Unknown git reference 'random'.",
-					Location: logs.Location{
-						Path: w.Path,
-					},
-				})
-
-				return fmt.Errorf("  Branch '%s' does not exists.", fun.Params.DefaultBranch)
+			hasChanges, err := fun.Eval()
+			if err != nil {
+				panic(err)
 			}
-
-			hasChanges := fun.Eval()
 
 			funInput := when.FunctionInput{
 				Name:   "change_in",

--- a/pkg/when/changein.go
+++ b/pkg/when/changein.go
@@ -67,7 +67,11 @@ func (f *ChangeInFunction) FetchBranch() error {
 
 	bytes, err := exec.Command("git", flags...).CombinedOutput()
 
-	return fmt.Errorf("Failed to fetch branch %w. Output: %s", err, string(bytes))
+	if err != nil {
+		return fmt.Errorf("Failed to fetch branch %w. Output: %s", err, string(bytes))
+	}
+
+	return nil
 }
 
 func (f *ChangeInFunction) MatchesPattern(diffLine string) bool {

--- a/pkg/when/changein.go
+++ b/pkg/when/changein.go
@@ -29,9 +29,11 @@ type ChangeInFunction struct {
 }
 
 func (f *ChangeInFunction) Eval() (bool, error) {
-	err := f.FetchBranch()
-	if err != nil {
-		return false, err
+	if environment.CurrentBranch() != f.Params.DefaultBranch {
+		err := f.FetchBranch()
+		if err != nil {
+			return false, err
+		}
 	}
 
 	f.LoadDiffList()
@@ -63,9 +65,9 @@ func (f *ChangeInFunction) FetchBranch() error {
 	flags := []string{"fetch", "origin", fmt.Sprintf("+refs/heads/%s:refs/heads/%s", f.Params.DefaultBranch, f.Params.DefaultBranch)}
 	fmt.Printf("  Running git %s\n", strings.Join(flags, " "))
 
-	_, err := exec.Command("git", flags...).CombinedOutput()
+	bytes, err := exec.Command("git", flags...).CombinedOutput()
 
-	return err
+	return fmt.Errorf("Failed to fetch branch %w. Output: %s", err, string(bytes))
 }
 
 func (f *ChangeInFunction) MatchesPattern(diffLine string) bool {

--- a/pkg/when/changein_parser.go
+++ b/pkg/when/changein_parser.go
@@ -7,6 +7,7 @@ import (
 
 	gabs "github.com/Jeffail/gabs/v2"
 	environment "github.com/semaphoreci/spc/pkg/environment"
+	logs "github.com/semaphoreci/spc/pkg/logs"
 )
 
 type ChangeInFunctionParser struct {
@@ -59,7 +60,11 @@ func (p *ChangeInFunctionParser) Execute() (*ChangeInFunction, error) {
 	return &ChangeInFunction{
 		Workdir:  path.Dir(p.yamlPath),
 		YamlPath: p.yamlPath,
-		Params:   params,
+		Location: logs.Location{
+			File: p.yamlPath,
+			Path: p.when.Path,
+		},
+		Params: params,
 	}, nil
 }
 

--- a/pkg/when/verify.go
+++ b/pkg/when/verify.go
@@ -1,0 +1,11 @@
+package when
+
+import (
+	"os/exec"
+)
+
+func IsInstalled() bool {
+	_, err := exec.Command("/bin/sh", "-c", "which when").CombinedOutput()
+
+	return err == nil
+}

--- a/test/e2e.rb
+++ b/test/e2e.rb
@@ -1,6 +1,6 @@
 # rubocop:disable all
 
-require_relative "e2e_utils/test_repo_for_change_in"
+require_relative "./e2e_utils/test_repo_for_change_in"
 
 def spc
   `echo "$(pwd)/build/cli"`.strip

--- a/test/e2e.rb
+++ b/test/e2e.rb
@@ -1,6 +1,8 @@
 # rubocop:disable all
 
 require_relative "./e2e_utils/test_repo_for_change_in"
+require 'yaml'
+require 'json'
 
 def spc
   `echo "$(pwd)/build/cli"`.strip

--- a/test/e2e.rb
+++ b/test/e2e.rb
@@ -1,5 +1,11 @@
 # rubocop:disable all
 
+require_relative "e2e_utils/test_repo_for_change_in"
+
+def spc
+  `echo "$(pwd)/build/cli"`.strip
+end
+
 def assert(bool)
   raise "failed" unless bool
 end
@@ -84,8 +90,4 @@ class Diff
     []
   end
 
-end
-
-def spc
-  `echo "$(pwd)/build/cli"`.strip
 end

--- a/test/e2e/change_in_all_possible_locations.rb
+++ b/test/e2e/change_in_all_possible_locations.rb
@@ -8,30 +8,7 @@
 require_relative "../e2e"
 require 'yaml'
 
-#
-# Prepare a repository with two branches, master and dev.
-#
-system %{
-  rm -f /tmp/output.yml
-  rm -rf /tmp/test-repo
-  mkdir /tmp/test-repo && cd /tmp/test-repo && git init
-
-  # master branch
-  mkdir lib .semaphore
-  echo A > lib/A.txt
-  git add . && git commit -m 'Bootstrap'
-
-  # dev branch
-  git checkout -b dev
-  echo B > lib/B.txt
-  git add . && git commit -m 'Changes in dev'
-}
-
-#
-# Create a .semaphore/semaphore.yml file.
-#
-
-File.write('/tmp/test-repo/.semaphore/semaphore.yml', %{
+pipeline = %{
 version: v1.0
 name: Test
 agent:
@@ -87,26 +64,25 @@ promotions:
   - name: Staging
     auto_promote:
       when: "branch = 'master' and change_in('/lib')"
-})
+}
 
-#
-# Evaluate the change-ins
-#
-system(%{
-  cd /tmp/test-repo
+origin = TestRepoForChangeIn.setup()
 
-  #{spc} evaluate change-in \
-     --input .semaphore/semaphore.yml \
-     --output /tmp/output.yml \
-     --logs /tmp/logs.yml
-})
+origin.add_file('.semaphore/semaphore.yml', pipeline)
+origin.commit!("Bootstrap")
 
-#
-# Verify that the results are OK.
-#
-output = YAML.load_file('/tmp/output.yml')
+origin.add_file("lib/A.txt", "hello")
+origin.commit!("Changes on master")
 
-assert_eq(output, YAML.load(%{
+origin.switch_branch("dev")
+origin.add_file("lib/B.txt", "hello")
+origin.commit!("Changes in dev")
+
+repo = origin.clone_local_copy(branch: "dev")
+repo.list_branches
+repo.run("#{spc} evaluate change-in --input .semaphore/semaphore.yml --output /tmp/output.yml --logs /tmp/logs.yml")
+
+assert_eq(YAML.load_file('/tmp/output.yml'), YAML.load(%{
 version: v1.0
 name: Test
 agent:

--- a/test/e2e/change_in_all_possible_locations.rb
+++ b/test/e2e/change_in_all_possible_locations.rb
@@ -74,7 +74,7 @@ origin.commit!("Bootstrap")
 origin.add_file("lib/A.txt", "hello")
 origin.commit!("Changes on master")
 
-origin.switch_branch("dev")
+origin.create_branch("dev")
 origin.add_file("lib/B.txt", "hello")
 origin.commit!("Changes in dev")
 

--- a/test/e2e/change_in_branch_range.rb
+++ b/test/e2e/change_in_branch_range.rb
@@ -3,22 +3,7 @@
 require_relative "../e2e"
 require 'yaml'
 
-#
-# Prepare a repository with two branches, master and dev.
-#
-system %{
-  rm -f /tmp/output.yml
-  rm -rf /tmp/test-repo
-  mkdir -p /tmp/test-repo/.semaphore
-  cd /tmp/test-repo
-  git init
-}
-
-#
-# Create a .semaphore/semaphore.yml file.
-#
-
-File.write('/tmp/test-repo/.semaphore/semaphore.yml', %{
+pipeline = %{
 version: v1.0
 name: Test
 agent:
@@ -41,15 +26,10 @@ blocks:
   - name: Test4
     run:
       when: "branch = 'master' and change_in('/lib', {branch_range: 'dev...$SEMAPHORE_GIT_SHA'})"
-})
+}
+
 
 system %{
-  cd /tmp/test-repo
-
-  mkdir lib app test
-
-  git add . && git commit -m "Bootstrap YAML"
-
   git checkout -b dev
 
   echo "hello" > app/a.yml
@@ -61,12 +41,21 @@ system %{
   git add . && git commit -m "Bootstrap lib"
 }
 
-#
-# Evaluate the change-ins
-#
-system(%{
-  cd /tmp/test-repo
+origin = TestRepoForChangeIn.setup()
 
+origin.add_file('.semaphore/semaphore.yml', pipeline)
+origin.commit!("Bootstrap")
+
+origin.create_branch("dev")
+origin.add_file("app/a.yml", "hello")
+origin.commit!("Bootstrap app")
+
+origin.create_branch("feature-1")
+origin.add_file("lib/a.yml", "hello")
+origin.commit!("Bootstrap lib")
+
+repo = origin.clone_local_copy(branch: "feature-1")
+repo.run(%{
   export SEMAPHORE_GIT_SHA=$(git rev-parse HEAD)
   export SEMAPHORE_MERGE_BASE=master
 
@@ -76,12 +65,7 @@ system(%{
      --logs /tmp/logs.yml
 })
 
-#
-# Verify that the results are OK.
-#
-output = YAML.load_file('/tmp/output.yml')
-
-assert_eq(output, YAML.load(%{
+assert_eq(YAML.load_file('/tmp/output.yml'), YAML.load(%{
 version: v1.0
 name: Test
 agent:

--- a/test/e2e/change_in_branch_range.rb
+++ b/test/e2e/change_in_branch_range.rb
@@ -28,19 +28,6 @@ blocks:
       when: "branch = 'master' and change_in('/lib', {branch_range: 'dev...$SEMAPHORE_GIT_SHA'})"
 }
 
-
-system %{
-  git checkout -b dev
-
-  echo "hello" > app/a.yml
-  git add . && git commit -m "Bootstrap app"
-
-  git checkout -b feature-1
-
-  echo "hello" > lib/b.yml
-  git add . && git commit -m "Bootstrap lib"
-}
-
 origin = TestRepoForChangeIn.setup()
 
 origin.add_file('.semaphore/semaphore.yml', pipeline)

--- a/test/e2e/change_in_glob.rb
+++ b/test/e2e/change_in_glob.rb
@@ -3,30 +3,7 @@
 require_relative "../e2e"
 require 'yaml'
 
-#
-# Prepare a repository with two branches, master and dev.
-#
-system %{
-  rm -f /tmp/output.yml
-  rm -rf /tmp/test-repo
-  mkdir /tmp/test-repo && cd /tmp/test-repo && git init
-
-  # master branch
-  mkdir lib .semaphore
-  echo A > lib/A.txt
-  git add . && git commit -m 'Bootstrap'
-
-  # dev branch
-  git checkout -b dev
-  echo B > lib/B.txt
-  git add . && git commit -m 'Changes in dev'
-}
-
-#
-# Create a .semaphore/semaphore.yml file.
-#
-
-File.write('/tmp/test-repo/.semaphore/semaphore.yml', %{
+pipeline = %{
 version: v1.0
 name: Test
 agent:
@@ -69,26 +46,24 @@ blocks:
         - name: Hello
           commands:
             - echo "Hello World"
-})
+}
 
-#
-# Evaluate the change-ins
-#
-system(%{
-  cd /tmp/test-repo
+origin = TestRepoForChangeIn.setup()
 
-  #{spc} evaluate change-in \
-     --input .semaphore/semaphore.yml \
-     --output /tmp/output.yml \
-     --logs /tmp/logs.yml
-})
+origin.add_file('.semaphore/semaphore.yml', pipeline)
+origin.commit!("Bootstrap")
 
-#
-# Verify that the results are OK.
-#
-output = YAML.load_file('/tmp/output.yml')
+origin.add_file("lib/A.txt", "hello")
+origin.commit!("Changes on master")
 
-assert_eq(output, YAML.load(%{
+origin.switch_branch("dev")
+origin.add_file("lib/B.txt", "hello")
+origin.commit!("Changes in dev")
+
+repo = origin.clone_local_copy(branch: "dev")
+repo.run("#{spc} evaluate change-in --input .semaphore/semaphore.yml --output /tmp/output.yml --logs /tmp/logs.yml")
+
+assert_eq(YAML.load_file('/tmp/output.yml'), YAML.load(%{
 version: v1.0
 name: Test
 agent:

--- a/test/e2e/change_in_glob.rb
+++ b/test/e2e/change_in_glob.rb
@@ -56,7 +56,7 @@ origin.commit!("Bootstrap")
 origin.add_file("lib/A.txt", "hello")
 origin.commit!("Changes on master")
 
-origin.switch_branch("dev")
+origin.create_branch("dev")
 origin.add_file("lib/B.txt", "hello")
 origin.commit!("Changes in dev")
 

--- a/test/e2e/change_in_multiple_paths.rb
+++ b/test/e2e/change_in_multiple_paths.rb
@@ -1,32 +1,8 @@
 # rubocop:disable all
 
 require_relative "../e2e"
-require 'yaml'
 
-#
-# Prepare a repository with two branches, master and dev.
-#
-system %{
-  rm -f /tmp/output.yml
-  rm -rf /tmp/test-repo
-  mkdir /tmp/test-repo && cd /tmp/test-repo && git init
-
-  # master branch
-  mkdir lib .semaphore
-  echo A > lib/A.txt
-  git add . && git commit -m 'Bootstrap'
-
-  # dev branch
-  git checkout -b dev
-  echo B > lib/B.txt
-  git add . && git commit -m 'Changes in dev'
-}
-
-#
-# Create a .semaphore/semaphore.yml file.
-#
-
-File.write('/tmp/test-repo/.semaphore/semaphore.yml', %{
+pipeline = %{
 version: v1.0
 name: Test
 agent:
@@ -51,26 +27,24 @@ blocks:
         - name: Hello
           commands:
             - echo "Hello World"
-})
+}
 
-#
-# Evaluate the change-ins
-#
-system(%{
-  cd /tmp/test-repo
+origin = TestRepoForChangeIn.setup()
 
-  #{spc} evaluate change-in \
-     --input .semaphore/semaphore.yml \
-     --output /tmp/output.yml \
-     --logs /tmp/logs.yml
-})
+origin.add_file('.semaphore/semaphore.yml', pipeline)
+origin.commit!("Bootstrap")
 
-#
-# Verify that the results are OK.
-#
-output = YAML.load_file('/tmp/output.yml')
+origin.add_file("lib/A.txt", "hello")
+origin.commit!("Changes on master")
 
-assert_eq(output, YAML.load(%{
+origin.create_branch("dev")
+origin.add_file("lib/B.txt", "hello")
+origin.commit!("Changes in dev")
+
+repo = origin.clone_local_copy(branch: "dev")
+repo.run("#{spc} evaluate change-in --input .semaphore/semaphore.yml --output /tmp/output.yml --logs /tmp/logs.yml")
+
+assert_eq(YAML.load_file('/tmp/output.yml'), YAML.load(%{
 version: v1.0
 name: Test
 agent:

--- a/test/e2e/change_in_on_tags.rb
+++ b/test/e2e/change_in_on_tags.rb
@@ -68,7 +68,7 @@ origin = TestRepoForChangeIn.setup()
 origin.add_file('.semaphore/semaphore.yml', pipeline)
 origin.commit!("Bootstrap")
 
-origin.switch_branch("dev")
+origin.create_branch("dev")
 origin.add_file("lib/B.txt", "hello")
 origin.commit!("Changes in dev")
 

--- a/test/e2e/change_in_on_tags.rb
+++ b/test/e2e/change_in_on_tags.rb
@@ -27,32 +27,7 @@ require 'yaml'
 # In which case the value will always be 'false' on tags.
 #
 
-#
-# Prepare a repository with two branches, master and dev.
-#
-system %{
-  rm -f /tmp/output.yml
-  rm -rf /tmp/test-repo
-  mkdir -p /tmp/test-repo
-  cd /tmp/test-repo
-  git init
-
-  # master branch
-  mkdir lib .semaphore
-  echo A > lib/A.txt
-  git add . && git commit -m 'Bootstrap'
-
-  # dev branch
-  git checkout -b dev
-  echo B > lib/B.txt
-  git add . && git commit -m 'Changes in dev'
-}
-
-#
-# Create a .semaphore/semaphore.yml file.
-#
-
-File.write('/tmp/test-repo/.semaphore/semaphore.yml', %{
+pipeline = %{
 version: v1.0
 name: Test
 agent:
@@ -86,26 +61,26 @@ blocks:
         - name: Hello
           commands:
             - echo "Hello World"
-})
+}
 
-#
-# Case 1: When the current git reference is a tag:
-#
+origin = TestRepoForChangeIn.setup()
 
-system(%{
-  cd /tmp/test-repo
+origin.add_file('.semaphore/semaphore.yml', pipeline)
+origin.commit!("Bootstrap")
 
+origin.switch_branch("dev")
+origin.add_file("lib/B.txt", "hello")
+origin.commit!("Changes in dev")
+
+repo = origin.clone_local_copy(branch: "dev")
+
+repo.run(%{
   export SEMAPHORE_GIT_REF_TYPE=tag
 
-  #{spc} evaluate change-in \
-     --input .semaphore/semaphore.yml \
-     --output /tmp/output.yml \
-     --logs /tmp/logs.yml
+  #{spc} evaluate change-in --input .semaphore/semaphore.yml --output /tmp/output.yml --logs /tmp/logs.yml
 })
 
-output = YAML.load_file('/tmp/output.yml')
-
-assert_eq(output, YAML.load(%{
+assert_eq(YAML.load_file('/tmp/output.yml'), YAML.load(%{
 version: v1.0
 name: Test
 agent:
@@ -141,24 +116,13 @@ blocks:
             - echo "Hello World"
 }))
 
-#
-# Case 2: When the current git reference is not a tag:
-#
-
-system(%{
-  cd /tmp/test-repo
-
+repo.run(%{
   export SEMAPHORE_GIT_REF_TYPE=branch
 
-  #{spc} evaluate change-in \
-     --input .semaphore/semaphore.yml \
-     --output /tmp/output.yml \
-     --logs /tmp/logs.yml
+  #{spc} evaluate change-in --input .semaphore/semaphore.yml --output /tmp/output.yml --logs /tmp/logs.yml
 })
 
-output = YAML.load_file('/tmp/output.yml')
-
-assert_eq(output, YAML.load(%{
+assert_eq(YAML.load_file('/tmp/output.yml'), YAML.load(%{
 version: v1.0
 name: Test
 agent:

--- a/test/e2e/change_in_relative_paths.rb
+++ b/test/e2e/change_in_relative_paths.rb
@@ -3,30 +3,7 @@
 require_relative "../e2e"
 require 'yaml'
 
-#
-# Prepare a repository with two branches, master and dev.
-#
-system %{
-  rm -f /tmp/output.yml
-  rm -rf /tmp/test-repo
-  mkdir /tmp/test-repo && cd /tmp/test-repo && git init
-
-  # master branch
-  mkdir lib .semaphore
-  echo A > lib/A.txt
-  git add . && git commit -m 'Bootstrap'
-
-  # dev branch
-  git checkout -b dev
-  echo B > lib/B.txt
-  git add . && git commit -m 'Changes in dev'
-}
-
-#
-# Create a .semaphore/semaphore.yml file.
-#
-
-File.write('/tmp/test-repo/.semaphore/semaphore.yml', %{
+pipeline = %{
 version: v1.0
 name: Test
 agent:
@@ -60,26 +37,24 @@ blocks:
         - name: Hello
           commands:
             - echo "Hello World"
-})
+}
 
-#
-# Evaluate the change-ins
-#
-system(%{
-  cd /tmp/test-repo
+origin = TestRepoForChangeIn.setup()
 
-  #{spc} evaluate change-in \
-     --input .semaphore/semaphore.yml \
-     --output /tmp/output.yml \
-     --logs /tmp/logs.yml
-})
+origin.add_file('.semaphore/semaphore.yml', pipeline)
+origin.commit!("Bootstrap")
 
-#
-# Verify that the results are OK.
-#
-output = YAML.load_file('/tmp/output.yml')
+origin.add_file("lib/A.txt", "hello")
+origin.commit!("Changes on master")
 
-assert_eq(output, YAML.load(%{
+origin.create_branch("dev")
+origin.add_file("lib/B.txt", "hello")
+origin.commit!("Changes in dev")
+
+repo = origin.clone_local_copy(branch: "dev")
+repo.run("#{spc} evaluate change-in --input .semaphore/semaphore.yml --output /tmp/output.yml --logs /tmp/logs.yml")
+
+assert_eq(YAML.load_file('/tmp/output.yml'), YAML.load(%{
 version: v1.0
 name: Test
 agent:

--- a/test/e2e/change_in_simple.rb
+++ b/test/e2e/change_in_simple.rb
@@ -38,7 +38,7 @@ origin.commit!("Bootstrap")
 origin.add_file("lib/A.txt", "hello")
 origin.commit!("Changes on master")
 
-origin.switch_branch("dev")
+origin.create_branch("dev")
 origin.add_file("lib/B.txt", "hello")
 origin.commit!("Changes in dev")
 

--- a/test/e2e/change_in_simple.rb
+++ b/test/e2e/change_in_simple.rb
@@ -43,6 +43,7 @@ origin.add_file("lib/B.txt", "hello")
 origin.commit!("Changes in dev")
 
 repo = origin.clone_local_copy(branch: "dev")
+repo.list_branches
 repo.run("#{spc} evaluate change-in --input .semaphore/semaphore.yml --output /tmp/output.yml --logs /tmp/logs.yml")
 
 assert_eq(YAML.load_file('/tmp/output.yml'), YAML.load(%{

--- a/test/e2e/change_in_simple.rb
+++ b/test/e2e/change_in_simple.rb
@@ -3,30 +3,7 @@
 require_relative "../e2e"
 require 'yaml'
 
-#
-# Prepare a repository with two branches, master and dev.
-#
-system %{
-  rm -f /tmp/output.yml
-  rm -rf /tmp/test-repo
-  mkdir /tmp/test-repo && cd /tmp/test-repo && git init
-
-  # master branch
-  mkdir lib .semaphore
-  echo A > lib/A.txt
-  git add . && git commit -m 'Bootstrap'
-
-  # dev branch
-  git checkout -b dev
-  echo B > lib/B.txt
-  git add . && git commit -m 'Changes in dev'
-}
-
-#
-# Create a .semaphore/semaphore.yml file.
-#
-
-File.write('/tmp/test-repo/.semaphore/semaphore.yml', %{
+pipeline = %{
 version: v1.0
 name: Test
 agent:
@@ -51,26 +28,24 @@ blocks:
         - name: Hello
           commands:
             - echo "Hello World"
-})
+}
 
-#
-# Evaluate the change-ins
-#
-system(%{
-  cd /tmp/test-repo
+origin = TestRepoForChangeIn.setup()
 
-  #{spc} evaluate change-in \
-     --input .semaphore/semaphore.yml \
-     --output /tmp/output.yml \
-     --logs /tmp/logs.yml
-})
+origin.add_file('.semaphore/semaphore.yml', pipeline)
+origin.commit!("Bootstrap")
 
-#
-# Verify that the results are OK.
-#
-output = YAML.load_file('/tmp/output.yml')
+origin.add_file("lib/A.txt", "hello")
+origin.commit!("Changes on master")
 
-assert_eq(output, YAML.load(%{
+origin.switch_branch("dev")
+origin.add_file("lib/B.txt", "hello")
+origin.commit!("Changes in dev")
+
+repo = origin.clone_local_copy(branch: "dev")
+repo.run("#{spc} evaluate change-in --input .semaphore/semaphore.yml --output /tmp/output.yml --logs /tmp/logs.yml")
+
+assert_eq(YAML.load_file('/tmp/output.yml'), YAML.load(%{
 version: v1.0
 name: Test
 agent:

--- a/test/e2e/change_in_simple.rb
+++ b/test/e2e/change_in_simple.rb
@@ -43,7 +43,6 @@ origin.add_file("lib/B.txt", "hello")
 origin.commit!("Changes in dev")
 
 repo = origin.clone_local_copy(branch: "dev")
-repo.list_branches
 repo.run("#{spc} evaluate change-in --input .semaphore/semaphore.yml --output /tmp/output.yml --logs /tmp/logs.yml")
 
 assert_eq(YAML.load_file('/tmp/output.yml'), YAML.load(%{

--- a/test/e2e/change_in_with_default_branch.rb
+++ b/test/e2e/change_in_with_default_branch.rb
@@ -1,37 +1,8 @@
 # rubocop:disable all
 
 require_relative "../e2e"
-require 'yaml'
 
-#
-# Prepare a repository with three branches, master, main, and dev.
-#
-system %{
-  rm -f /tmp/output.yml
-  rm -rf /tmp/test-repo
-  mkdir /tmp/test-repo && cd /tmp/test-repo && git init
-
-  # master branch
-  mkdir app lib .semaphore
-  echo A > app/A.txt
-  git add . && git commit -m 'Bootstrap'
-
-  # main branch
-  git checkout -b main
-  echo B > lib/B.txt
-  git add . && git commit -m 'Changes in main branch'
-
-  # dev branch
-  git checkout -b dev
-  echo C > app/C.txt
-  git add . && git commit -m 'Changes in dev'
-}
-
-#
-# Create a .semaphore/semaphore.yml file.
-#
-
-File.write('/tmp/test-repo/.semaphore/semaphore.yml', %{
+pipeline = %{
 version: v1.0
 name: Test
 agent:
@@ -65,26 +36,28 @@ blocks:
         - name: Hello
           commands:
             - echo "Hello World"
-})
+}
 
-#
-# Evaluate the change-ins
-#
-system(%{
-  cd /tmp/test-repo
+origin = TestRepoForChangeIn.setup()
 
-  #{spc} evaluate change-in \
-     --input .semaphore/semaphore.yml \
-     --output /tmp/output.yml \
-     --logs /tmp/logs.yml
-})
+origin.add_file('.semaphore/semaphore.yml', pipeline)
+origin.commit!("Bootstrap")
 
-#
-# Verify that the results are OK.
-#
-output = YAML.load_file('/tmp/output.yml')
+origin.add_file("app/A.txt", "hello")
+origin.commit!("Changes on master")
 
-assert_eq(output, YAML.load(%{
+origin.create_branch("main")
+origin.add_file("lib/B.txt", "hello")
+origin.commit!("Changes in main")
+
+origin.create_branch("dev")
+origin.add_file("app/C.txt", "hello")
+origin.commit!("Changes in dev")
+
+repo = origin.clone_local_copy(branch: "dev")
+repo.run("#{spc} evaluate change-in --input .semaphore/semaphore.yml --output /tmp/output.yml --logs /tmp/logs.yml")
+
+assert_eq(YAML.load_file('/tmp/output.yml'), YAML.load(%{
 version: v1.0
 name: Test
 agent:

--- a/test/e2e_utils/test_repo_for_change_in.rb
+++ b/test/e2e_utils/test_repo_for_change_in.rb
@@ -48,14 +48,16 @@ class TestRepoForChangeIn
   end
 
   # Run a command in the context or the repository
-  def run(commands)
+  def run(commands, options = {})
     system %{
       cd #{@path}
 
       #{commands}
     }
 
-    raise "Failed to execute command" if $?.exitstatus != 0
+    if options[:fail] != false
+      raise "Failed to execute command" if $?.exitstatus != 0
+    end
   end
 
   def list_branches

--- a/test/e2e_utils/test_repo_for_change_in.rb
+++ b/test/e2e_utils/test_repo_for_change_in.rb
@@ -54,6 +54,8 @@ class TestRepoForChangeIn
 
       #{commands}
     }
+
+    raise "Failed to execute command" if $?.exitstatus != 0
   end
 
   def list_branches
@@ -61,6 +63,10 @@ class TestRepoForChangeIn
   end
 
   def switch_branch(name)
+    run("git checkout #{name}")
+  end
+
+  def create_branch(name)
     run("git checkout -b #{name}")
   end
 

--- a/test/e2e_utils/test_repo_for_change_in.rb
+++ b/test/e2e_utils/test_repo_for_change_in.rb
@@ -1,0 +1,55 @@
+# rubocop:disable all
+
+class TestRepoForChangeIn
+  def self.setup(path)
+    path = "/tmp/test-repo-#{origin}"
+
+    system "rm -rf #{path}"
+    system "mkdir -p #{path}"
+
+    repo = new(path)
+
+    repo.run(%{
+      git init
+      mkdir .semaphore
+    })
+
+    repo
+  end
+
+  def initialize(path)
+    @path = path
+  end
+
+  # Run a command in the context or the repository
+  def run(commands)
+    system %{
+      cd #{@path}
+
+      #{commands}
+    }
+  end
+
+  def switch_branch(name)
+    run("git checkout -b #{name}")
+  end
+
+  def add_file(file_path, content)
+    File.write(Path.join(@path, file_path), content)
+  end
+
+  def commit!(message)
+    run("git add . && git commit -m '#{message}'")
+  end
+
+  def clone_local_copy(options = {})
+    clone_path = "/tmp/test-repo"
+
+    system "rm -rf #{clone_path}"
+    system "git clone #{@path} --branch #{options[:branch]} #{clone_path}"
+
+    repo = new(clone_path)
+
+    repo
+  end
+end

--- a/test/e2e_utils/test_repo_for_change_in.rb
+++ b/test/e2e_utils/test_repo_for_change_in.rb
@@ -1,8 +1,34 @@
 # rubocop:disable all
 
+#
+# The TestRepoForChangeIn initializes a repository on your local
+# machine. It creates the equivalent of a GitHub hosted "origin"
+# repository. You will need to "clone" before using it for testing.
+#
+# Usage:
+#
+# 1. Create an 'origin':
+#
+#   origin = TestRepoForChangeIn.setup()
+#
+# 2. Add a file:
+#
+#   origin.add_file("README.md", "hello")
+#
+# 3. Commit:
+#
+#   origin.commit!("Bootstrap")
+#
+# 4. Clone the repository:
+#
+#   local_copy = origin.clone_local_copy(branch: "master")
+#
+#   local_copy.list_branches()
+#
+
 class TestRepoForChangeIn
-  def self.setup(path)
-    path = "/tmp/test-repo-#{origin}"
+  def self.setup
+    path = "/tmp/test-repo-origin"
 
     system "rm -rf #{path}"
     system "mkdir -p #{path}"
@@ -30,12 +56,19 @@ class TestRepoForChangeIn
     }
   end
 
+  def list_branches
+    run "git branch -a"
+  end
+
   def switch_branch(name)
     run("git checkout -b #{name}")
   end
 
   def add_file(file_path, content)
-    File.write(Path.join(@path, file_path), content)
+    full_path = File.join(@path, file_path)
+    system "mkdir -p #{File.dirname(full_path)}"
+
+    File.write(full_path, content)
   end
 
   def commit!(message)
@@ -48,7 +81,7 @@ class TestRepoForChangeIn
     system "rm -rf #{clone_path}"
     system "git clone #{@path} --branch #{options[:branch]} #{clone_path}"
 
-    repo = new(clone_path)
+    repo = TestRepoForChangeIn.new(clone_path)
 
     repo
   end


### PR DESCRIPTION
Problem:

`checkout` in a semaphore job only checks out one branch, for example, "development".
Now, if we run `change_in("/", range: master..HEAD)` the compiler will yell at us "master branch does not exists!".

We need to fetch the branch before running the evaluation.

---

Solution:

There are two parts to this PR:

- (easy) Add a `git fetch $branch` before running `git dif` that evaluates `change_in`.
- (hard) Have "remote" and "local" repositories in a test environment

The "remote" and "local" repo could be done by setting up a repository on GitHub and cloning it down.
However, this is definitely not the most flexible approach in the test.

Instead, I'm trying out:

- Have a `/tmp/temp-repo-origin`
- Clone a copy with `git clone /tmp/temp-repo-origin /tmp/temp-repo-local`
- Run tests in `/tmp/temp-repo-local`