### PR TITLE
Make change_in work on PR triggered pipelines

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -60,6 +60,7 @@ blocks:
                 - test/e2e/change_in_missing_branch.rb
                 - test/e2e/change_in_multiple_paths.rb
                 - test/e2e/change_in_on_tags.rb
+                - test/e2e/change_in_on_prs.rb
                 - test/e2e/change_in_pipeline_file_tracking.rb
                 - test/e2e/change_in_relative_paths.rb
                 - test/e2e/change_in_simple.rb

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -8,6 +8,7 @@ import (
 
 const GitRefTypeTag = "tag"
 const GitRefTypeBranch = "branch"
+const GitRefTypePullRequest = "pull-request"
 
 func GitRefType() string {
 	value := os.Getenv("SEMAPHORE_GIT_REF_TYPE")
@@ -18,6 +19,8 @@ func GitRefType() string {
 	return GitRefTypeBranch
 }
 
+// In pipelines initiated by Pull Request, this environment variable
+// points to branch that is the TARGET of pull request
 func CurrentBranch() string {
 	value := os.Getenv("SEMAPHORE_GIT_BRANCH")
 	if value != "" {
@@ -30,6 +33,12 @@ func CurrentBranch() string {
 	}
 
 	return strings.TrimSpace(string(gitBranch))
+}
+
+// In pipelines initiated by Pull Requests, this environment variable
+// points to branch that contains all the changes that should be merged
+func PullRequestBranch() string {
+	return os.Getenv("SEMAPHORE_GIT_PR_BRANCH")
 }
 
 func GitCommitRange() string {

--- a/pkg/when/changein/eval.go
+++ b/pkg/when/changein/eval.go
@@ -22,6 +22,9 @@ type evaluator struct {
 	err      error
 }
 
+const ThreeDots = "..."
+const TwoDots = ".."
+
 func (e *evaluator) Run() (bool, error) {
 	fmt.Println("Processing change_in function")
 	fmt.Println("Params:")
@@ -68,10 +71,10 @@ func (e *evaluator) runningOnDefaultBranch() bool {
 func (e *evaluator) CommitRangeBase() string {
 	var splitAt string
 
-	if strings.Contains(e.CommitRange(), "...") {
-		splitAt = "..."
+	if strings.Contains(e.CommitRange(), ThreeDots) {
+		splitAt = ThreeDots
 	} else {
-		splitAt = ".."
+		splitAt = TwoDots
 	}
 
 	parts := strings.Split(e.CommitRange(), splitAt)
@@ -82,10 +85,10 @@ func (e *evaluator) CommitRangeBase() string {
 func (e *evaluator) CommitRangeHead() string {
 	var splitAt string
 
-	if strings.Contains(e.CommitRange(), "...") {
-		splitAt = "..."
+	if strings.Contains(e.CommitRange(), ThreeDots) {
+		splitAt = ThreeDots
 	} else {
-		splitAt = ".."
+		splitAt = TwoDots
 	}
 
 	parts := strings.Split(e.CommitRange(), splitAt)

--- a/pkg/when/changein/function.go
+++ b/pkg/when/changein/function.go
@@ -17,7 +17,8 @@ type Function struct {
 	TrackPipelineFile    bool
 	OnTags               bool
 	DefaultRange         string
-	CommitRange          string
+	BranchRange          string
+	PullRequestRange     string
 }
 
 func (f *Function) HasMatchesInDiffList(diffList []string) bool {

--- a/test/e2e/change_in_on_prs.rb
+++ b/test/e2e/change_in_on_prs.rb
@@ -1,0 +1,93 @@
+# rubocop:disable all
+
+#
+# In pipelines triggered by PRs Semaphore checkouts the merge commit as a
+# detached head. That makes evaluating change_in tricky because merge commit
+# includes changes made to target branch  after the branch that is the source of
+# the PR diverged from targeted branch.
+#
+# In order to get proper changeset we need to fetch both source and target
+# branches, since target might not be master.
+# After that we can use "<target_branch>....<pr_source_branch>" as a commit
+# range for change_in since it does not include changes made to target branch
+# after the source branch diverged.
+#
+# This test simulates this state by creating repo with two branches, merging
+# them and reseting HEAD of target branch back by one so merge commit becomes
+# a detached head when it is checked out.
+#
+
+require_relative "../e2e"
+require 'yaml'
+
+pipeline = %{
+version: v1.0
+name: Test
+agent:
+  machine:
+    type: e1-standard-2
+
+blocks:
+  - name: Test
+    run:
+      when: "branch = 'master' and change_in('/app')"
+
+  - name: Test2
+    run:
+      when: "branch = 'master' and change_in('/lib')"
+}
+
+origin = TestRepoForChangeIn.setup()
+
+origin.add_file('.semaphore/semaphore.yml', pipeline)
+origin.commit!("Bootstrap")
+
+origin.create_branch("dev")
+origin.add_file("app/a.yml", "hello")
+origin.commit!("Bootstrap app")
+
+origin.switch_branch("master")
+origin.add_file("lib/b.yml", "world")
+origin.commit!("Bootstrap lib")
+
+origin.merge_branch("dev")
+
+repo = origin.clone_local_copy(branch: "master")
+
+origin.run(%{
+  git reset --hard HEAD~1
+})
+
+repo.run(%{
+  export SEMAPHORE_GIT_SHA=$(git rev-parse HEAD)
+
+  git reset --hard HEAD~1
+
+  git checkout $SEMAPHORE_GIT_SHA
+
+  export SEMAPHORE_GIT_REF_TYPE=pull-request
+  export SEMAPHORE_GIT_BRANCH=master
+  export SEMAPHORE_GIT_PR_BRANCH=dev
+
+  #{spc} evaluate change-in \
+     --input .semaphore/semaphore.yml \
+     --output /tmp/output.yml \
+     --logs /tmp/logs.yml
+})
+
+assert_eq(YAML.load_file('/tmp/output.yml'), YAML.load(%{
+version: v1.0
+name: Test
+agent:
+  machine:
+    type: e1-standard-2
+
+blocks:
+  - name: Test
+    run:
+      when: "(branch = 'master') and true"
+
+  - name: Test2
+    run:
+      when: "(branch = 'master') and false"
+}))

--- a/test/e2e_utils/test_repo_for_change_in.rb
+++ b/test/e2e_utils/test_repo_for_change_in.rb
@@ -72,6 +72,10 @@ class TestRepoForChangeIn
     run("git checkout -b #{name}")
   end
 
+  def merge_branch(name)
+    run("git merge --no-edit #{name}")
+  end
+
   def add_file(file_path, content)
     full_path = File.join(@path, file_path)
     system "mkdir -p #{File.dirname(full_path)}"


### PR DESCRIPTION
Main changes are the way commit range for diff is calculated on PR triggered pipelines and added fetching of the source branch of pull request. Additional description can be found in the new test for this use case.