### PR TITLE
Deepen shallow clones before running diff

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -69,6 +69,7 @@ blocks:
                 - test/e2e/change_in_simple.rb
                 - test/e2e/change_in_with_default_branch.rb
                 - test/e2e/change_in_java_vs_javascript_clash.rb
+                - test/e2e/change_in_large_commit_diff.rb
                 - test/e2e/when_conditions_without_change_in.rb
 
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -70,6 +70,7 @@ blocks:
                 - test/e2e/change_in_with_default_branch.rb
                 - test/e2e/change_in_java_vs_javascript_clash.rb
                 - test/e2e/change_in_large_commit_diff.rb
+                - test/e2e/change_in_large_commit_diff_on_default_branch.rb
                 - test/e2e/when_conditions_without_change_in.rb
 
           commands:

--- a/pkg/when/changein/eval.go
+++ b/pkg/when/changein/eval.go
@@ -117,7 +117,7 @@ func (e *evaluator) FetchBranches() error {
 
 		result, err := git.Fetch(pullRequestBranch)
 		if err != nil {
-			return e.ParseFetchError(pullRequestBranch, string(result), err)
+			return e.ParseFetchError(pullRequestBranch, result, err)
 		}
 	}
 
@@ -125,15 +125,10 @@ func (e *evaluator) FetchBranches() error {
 
 	output, err := git.Fetch(base)
 	if err != nil {
-		return e.ParseFetchError(base, string(output), err)
+		return e.ParseFetchError(base, output, err)
 	}
 
-	err = e.ParseFetchError(base, string(output), err)
-	if err != nil {
-		return err
-	}
-
-	return git.Unshallow("aaa")
+	return e.ParseFetchError(base, output, err)
 }
 
 func (e *evaluator) ParseFetchError(name string, output string, err error) error {
@@ -150,6 +145,11 @@ func (e *evaluator) ParseFetchError(name string, output string, err error) error
 }
 
 func (e *evaluator) LoadDiffList() ([]string, error) {
+	err := git.Unshallow(e.CommitRange())
+	if err != nil {
+		return []string{}, nil
+	}
+
 	list, _, err := git.Diff(e.CommitRange())
 	if err != nil {
 		return list, err

--- a/pkg/when/changein/eval.go
+++ b/pkg/when/changein/eval.go
@@ -128,7 +128,12 @@ func (e *evaluator) FetchBranches() error {
 		return e.ParseFetchError(base, string(output), err)
 	}
 
-	return e.ParseFetchError(base, string(output), err)
+	err = e.ParseFetchError(base, string(output), err)
+	if err != nil {
+		return err
+	}
+
+	return git.Unshallow("aaa")
 }
 
 func (e *evaluator) ParseFetchError(name string, output string, err error) error {

--- a/test/e2e/change_in_large_commit_diff.rb
+++ b/test/e2e/change_in_large_commit_diff.rb
@@ -32,13 +32,13 @@ origin.commit!("Changes on master")
 # diverge master and dev by 100 commits
 
 origin.create_branch("dev")
-100.times do |index|
+300.times do |index|
   origin.add_file("lib/B#{index}.txt", "hello")
   origin.commit!("Changes in dev number #{index}")
 end
 
 origin.switch_branch("master")
-100.times do |index|
+300.times do |index|
   origin.add_file("lib/B#{index}.txt", "hello")
   origin.commit!("Changes in master number #{index}")
 end

--- a/test/e2e/change_in_large_commit_diff.rb
+++ b/test/e2e/change_in_large_commit_diff.rb
@@ -29,12 +29,21 @@ origin.commit!("Bootstrap")
 origin.add_file("lib/A.txt", "hello")
 origin.commit!("Changes on master")
 
-origin.create_branch("dev")
+# diverge master and dev by 100 commits
 
+origin.create_branch("dev")
 100.times do |index|
   origin.add_file("lib/B#{index}.txt", "hello")
   origin.commit!("Changes in dev number #{index}")
 end
+
+origin.switch_branch("master")
+100.times do |index|
+  origin.add_file("lib/B#{index}.txt", "hello")
+  origin.commit!("Changes in master number #{index}")
+end
+
+origin.switch_branch("dev")
 
 repo = origin.clone_local_copy(branch: "dev")
 repo.run("#{spc} evaluate change-in --input .semaphore/semaphore.yml --output /tmp/output.yml --logs /tmp/logs.yml")

--- a/test/e2e/change_in_large_commit_diff.rb
+++ b/test/e2e/change_in_large_commit_diff.rb
@@ -1,0 +1,67 @@
+# rubocop:disable all
+
+require_relative "../e2e"
+require 'yaml'
+
+pipeline = %{
+version: v1.0
+name: Test
+agent:
+  machine:
+    type: e1-standard-2
+
+blocks:
+  - name: Test
+    run:
+      when: "branch = 'master' and change_in('/lib')"
+    task:
+      jobs:
+        - name: Hello
+          commands:
+            - echo "Hello World"
+}
+
+origin = TestRepoForChangeIn.setup()
+
+origin.add_file('.semaphore/semaphore.yml', pipeline)
+origin.commit!("Bootstrap")
+
+origin.add_file("lib/A.txt", "hello")
+origin.commit!("Changes on master")
+
+origin.create_branch("dev")
+
+100.times do |index|
+  origin.add_file("lib/B#{index}.txt", "hello")
+  origin.commit!("Changes in dev number #{index}")
+end
+
+repo = origin.clone_local_copy(branch: "dev")
+repo.run("#{spc} evaluate change-in --input .semaphore/semaphore.yml --output /tmp/output.yml --logs /tmp/logs.yml")
+
+assert_eq(YAML.load_file('/tmp/output.yml'), YAML.load(%{
+version: v1.0
+name: Test
+agent:
+  machine:
+    type: e1-standard-2
+
+blocks:
+  - name: Test
+    run:
+      when: "(branch = 'master') and true"
+    task:
+      jobs:
+        - name: Hello
+          commands:
+            - echo "Hello World"
+
+  - name: Test2
+    run:
+      when: "(branch = 'master') and false"
+    task:
+      jobs:
+        - name: Hello
+          commands:
+            - echo "Hello World"
+}))

--- a/test/e2e/change_in_large_commit_diff.rb
+++ b/test/e2e/change_in_large_commit_diff.rb
@@ -32,13 +32,13 @@ origin.commit!("Changes on master")
 # diverge master and dev by 100 commits
 
 origin.create_branch("dev")
-300.times do |index|
+350.times do |index|
   origin.add_file("lib/B#{index}.txt", "hello")
   origin.commit!("Changes in dev number #{index}")
 end
 
 origin.switch_branch("master")
-300.times do |index|
+350.times do |index|
   origin.add_file("lib/B#{index}.txt", "hello")
   origin.commit!("Changes in master number #{index}")
 end

--- a/test/e2e/change_in_large_commit_diff_on_default_branch.rb
+++ b/test/e2e/change_in_large_commit_diff_on_default_branch.rb
@@ -29,24 +29,17 @@ origin.commit!("Bootstrap")
 origin.add_file("lib/A.txt", "hello")
 origin.commit!("Changes on master")
 
-# diverge master and dev by 100 commits
-
-origin.create_branch("dev")
-300.times do |index|
-  origin.add_file("lib/B#{index}.txt", "hello")
-  origin.commit!("Changes in dev number #{index}")
-end
-
-origin.switch_branch("master")
 300.times do |index|
   origin.add_file("lib/B#{index}.txt", "hello")
   origin.commit!("Changes in master number #{index}")
 end
 
-origin.switch_branch("dev")
+repo = origin.clone_local_copy(branch: "master")
+repo.run(%{
+  export SEMAPHORE_GIT_COMMIT_RANGE="$(cd ../test-repo-origin && git rev-parse HEAD~98)...$(cd ../test-repo-origin && git rev-parse HEAD)"
 
-repo = origin.clone_local_copy(branch: "dev")
-repo.run("#{spc} evaluate change-in --input .semaphore/semaphore.yml --output /tmp/output.yml --logs /tmp/logs.yml")
+  #{spc} evaluate change-in --input .semaphore/semaphore.yml --output /tmp/output.yml --logs /tmp/logs.yml
+})
 
 assert_eq(YAML.load_file('/tmp/output.yml'), YAML.load(%{
 version: v1.0

--- a/test/e2e/change_in_large_commit_diff_on_default_branch.rb
+++ b/test/e2e/change_in_large_commit_diff_on_default_branch.rb
@@ -29,7 +29,7 @@ origin.commit!("Bootstrap")
 origin.add_file("lib/A.txt", "hello")
 origin.commit!("Changes on master")
 
-300.times do |index|
+350.times do |index|
   origin.add_file("lib/B#{index}.txt", "hello")
   origin.commit!("Changes in master number #{index}")
 end

--- a/test/e2e/change_in_large_commit_diff_on_default_branch.rb
+++ b/test/e2e/change_in_large_commit_diff_on_default_branch.rb
@@ -36,7 +36,7 @@ end
 
 repo = origin.clone_local_copy(branch: "master")
 repo.run(%{
-  export SEMAPHORE_GIT_COMMIT_RANGE="$(cd ../test-repo-origin && git rev-parse HEAD~98)...$(cd ../test-repo-origin && git rev-parse HEAD)"
+  export SEMAPHORE_GIT_COMMIT_RANGE="$(cd ../test-repo-origin && git rev-parse HEAD~95)...$(cd ../test-repo-origin && git rev-parse HEAD)"
 
   #{spc} evaluate change-in --input .semaphore/semaphore.yml --output /tmp/output.yml --logs /tmp/logs.yml
 })

--- a/test/e2e_utils/test_repo_for_change_in.rb
+++ b/test/e2e_utils/test_repo_for_change_in.rb
@@ -91,7 +91,7 @@ class TestRepoForChangeIn
     clone_path = "/tmp/test-repo"
 
     system "rm -rf #{clone_path}"
-    system "git clone #{@path} --branch #{options[:branch]} #{clone_path}"
+    system "git clone #{@path} --depth 10 --branch #{options[:branch]} #{clone_path}"
 
     repo = TestRepoForChangeIn.new(clone_path)
 

--- a/test/e2e_utils/test_repo_for_change_in.rb
+++ b/test/e2e_utils/test_repo_for_change_in.rb
@@ -91,7 +91,7 @@ class TestRepoForChangeIn
     clone_path = "/tmp/test-repo"
 
     system "rm -rf #{clone_path}"
-    system "git clone #{@path} --depth 10 --branch #{options[:branch]} #{clone_path}"
+    system "git clone file:///#{@path} --depth 10 --branch #{options[:branch]} #{clone_path}"
 
     repo = TestRepoForChangeIn.new(clone_path)
 


### PR DESCRIPTION
If the cloned repository is not deep enough (cloned with --depth N), the change_in evaluation fails.

In this PR, we are introducing a procedure for an iterative deepening of the git history until change_in is ready to be resolved.

Demonstrative pseudocode:

``` ruby
while gitDiffIsFailing? do
  run "git fetch --deepen 100"
end
```

We are running with an iterative approach instead of a full clone in order to better support large git repositories. For example, a full git clone can be 80gb, but the relevant parts (the last N commits) might be much lighter.

The iterative deepening will halt with an error at 10,000 commits. This should be enough for most, if not all use cases.

When this change is introduced, the output of the CLI will be:

![Screenshot 2021-03-31 at 15 52 17](https://user-images.githubusercontent.com/1779493/113155248-1c44e380-9239-11eb-8331-a227b9a8ad87.png)
