### PR TITLE
Substitute env vars in Docker Images and change_in expressions.

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -58,7 +58,11 @@ blocks:
                 - test/e2e/change_in_excluded_paths.rb
                 - test/e2e/change_in_glob.rb
                 - test/e2e/change_in_invalid_when.rb
+                - test/e2e/change_in_java_vs_javascript_clash.rb
+                - test/e2e/change_in_large_commit_diff.rb
+                - test/e2e/change_in_large_commit_diff_on_default_branch.rb
                 - test/e2e/change_in_missing_branch.rb
+                - test/e2e/change_in_multiple_functions_in_one_when.rb
                 - test/e2e/change_in_multiple_paths.rb
                 - test/e2e/change_in_on_forked_prs.rb
                 - test/e2e/change_in_on_prs.rb
@@ -68,9 +72,8 @@ blocks:
                 - test/e2e/change_in_relative_paths.rb
                 - test/e2e/change_in_simple.rb
                 - test/e2e/change_in_with_default_branch.rb
-                - test/e2e/change_in_java_vs_javascript_clash.rb
-                - test/e2e/change_in_large_commit_diff.rb
-                - test/e2e/change_in_large_commit_diff_on_default_branch.rb
+                - test/e2e/env_simple.rb
+                - test/e2e/env_vars_in_docker_images.rb
                 - test/e2e/when_conditions_without_change_in.rb
 
           commands:

--- a/pkg/cli/evaluate.go
+++ b/pkg/cli/evaluate.go
@@ -34,6 +34,9 @@ var evaluateChangeInCmd = &cobra.Command{
 		ppl, err := pipelines.LoadFromFile(input)
 		check(err)
 
+		err = ppl.SubstituteEnvVarsInDockerImages()
+		check(err)
+
 		err = ppl.EvaluateChangeIns()
 		check(err)
 

--- a/pkg/pipelines/model.go
+++ b/pkg/pipelines/model.go
@@ -2,6 +2,7 @@ package pipelines
 
 import (
 	"encoding/json"
+	"os"
 	"strconv"
 	"time"
 
@@ -25,43 +26,53 @@ func (p *Pipeline) UpdateString(path []string, value string) error {
 	return err
 }
 
+func (p *Pipeline) GetStringValueFrom(path []string) (string, bool) {
+	val, ok := p.raw.Search(path...).Data().(string)
+	return val, ok
+}
+
 func (p *Pipeline) EvaluateChangeIns() error {
 	return newWhenEvaluator(p).Run()
 }
 
 func (p *Pipeline) SubstituteEnvVarsInDockerImages() error {
-	consolelogger.Infof("Substituting aaaa\n")
+	consolelogger.Info("Expanding environment variables in YAML file")
+	consolelogger.EmptyLine()
 
 	containers := p.raw.Search("agent", "containers").Children()
 
 	for containerIndex := range containers {
-		consolelogger.Infof("Substituting bbb\n")
-
 		path := []string{"agent", "containers", strconv.Itoa(containerIndex), "image"}
-		newValue := "hello"
 
-		p.UpdateString(path, newValue)
+		p.expandEnvIfExists(path)
 	}
 
 	for blockIndex := range p.Blocks() {
-		consolelogger.Infof("Substituting ccc\n")
-
 		path := []string{"blocks", strconv.Itoa(blockIndex), "agent", "containers"}
 
 		containers := p.raw.Search(path...).Children()
 
 		for containerIndex := range containers {
-			consolelogger.Infof("Substituting %d", containerIndex)
-
 			path := append(path, []string{strconv.Itoa(containerIndex), "image"}...)
 
-			newValue := "hello"
-
-			p.UpdateString(path, newValue)
+			p.expandEnvIfExists(path)
 		}
 	}
 
 	return nil
+}
+
+func (p *Pipeline) expandEnvIfExists(path []string) {
+	if value, ok := p.GetStringValueFrom(path); ok {
+		newValue := os.ExpandEnv(value)
+
+		consolelogger.Infof("Expanding env vars in %+v\n", path)
+		consolelogger.Infof("Original: '%s'\n", value)
+		consolelogger.Infof("Expanded: '%s'\n", newValue)
+		consolelogger.EmptyLine()
+
+		p.UpdateString(path, newValue)
+	}
 }
 
 func (p *Pipeline) Blocks() []*gabs.Container {

--- a/pkg/pipelines/when_evaluator.go
+++ b/pkg/pipelines/when_evaluator.go
@@ -55,7 +55,7 @@ func (e *whenEvaluator) Run() error {
 
 func (e *whenEvaluator) updatePipeline() error {
 	for index := range e.results {
-		err := e.pipeline.UpdateWhenExpression(e.list[index].Path, e.results[index])
+		err := e.pipeline.UpdateString(e.list[index].Path, e.results[index])
 
 		if err != nil {
 			return err

--- a/pkg/when/env/env.go
+++ b/pkg/when/env/env.go
@@ -1,0 +1,36 @@
+package env
+
+import (
+	"fmt"
+	"os"
+
+	gabs "github.com/Jeffail/gabs/v2"
+	consolelogger "github.com/semaphoreci/spc/pkg/consolelogger"
+)
+
+type Function struct {
+	VarName string
+}
+
+func Parse(ast *gabs.Container) (*Function, error) {
+	firstArg := ast.Search("params", "0")
+
+	if !firstArg.Exists() {
+		return nil, fmt.Errorf("variable name not found in env function")
+	}
+
+	varName, ok := firstArg.Data().(string)
+	if !ok {
+		return nil, fmt.Errorf("invalid variable name in env function")
+	}
+
+	return &Function{VarName: varName}, nil
+}
+
+func Eval(fun *Function) (string, error) {
+	value := os.Getenv(fun.VarName)
+
+	consolelogger.Infof("Result: '%+v'\n", value)
+
+	return value, nil
+}

--- a/pkg/when/expression.go
+++ b/pkg/when/expression.go
@@ -4,6 +4,7 @@ import (
 	gabs "github.com/Jeffail/gabs/v2"
 	consolelogger "github.com/semaphoreci/spc/pkg/consolelogger"
 	changein "github.com/semaphoreci/spc/pkg/when/changein"
+	env "github.com/semaphoreci/spc/pkg/when/env"
 	whencli "github.com/semaphoreci/spc/pkg/when/whencli"
 )
 
@@ -17,7 +18,22 @@ type WhenExpression struct {
 
 func (w *WhenExpression) Eval() error {
 	for _, requirment := range w.ListChangeInFunctions(w.Requirments) {
-		result, err := w.EvalFunction(requirment)
+		result, err := w.EvaluateChangeInFunction(requirment)
+		if err != nil {
+			return err
+		}
+
+		input := map[string]interface{}{}
+		input["name"] = w.functionName(requirment)
+		input["params"] = w.functionParams(requirment)
+		input["result"] = result
+
+		w.ReduceInputs.Keywords = map[string]interface{}{}
+		w.ReduceInputs.Functions = append(w.ReduceInputs.Functions, input)
+	}
+
+	for _, requirment := range w.ListEnvFunctions(w.Requirments) {
+		result, err := w.EvaluateEnvFunction(requirment)
 		if err != nil {
 			return err
 		}
@@ -46,6 +62,18 @@ func (w *WhenExpression) ListChangeInFunctions(requirments *gabs.Container) []*g
 	return result
 }
 
+func (w *WhenExpression) ListEnvFunctions(requirments *gabs.Container) []*gabs.Container {
+	result := []*gabs.Container{}
+
+	for _, input := range requirments.Children() {
+		if w.IsEnvFunction(input) {
+			result = append(result, input)
+		}
+	}
+
+	return result
+}
+
 func (w *WhenExpression) IsChangeInFunction(input *gabs.Container) bool {
 	elType := input.Search("type").Data().(string)
 	if elType != "fun" {
@@ -59,7 +87,20 @@ func (w *WhenExpression) IsChangeInFunction(input *gabs.Container) bool {
 	return true
 }
 
-func (w *WhenExpression) EvalFunction(input *gabs.Container) (bool, error) {
+func (w *WhenExpression) IsEnvFunction(input *gabs.Container) bool {
+	elType := input.Search("type").Data().(string)
+	if elType != "fun" {
+		return false
+	}
+
+	if w.functionName(input) != "env" {
+		return false
+	}
+
+	return true
+}
+
+func (w *WhenExpression) EvaluateChangeInFunction(input *gabs.Container) (bool, error) {
 	consolelogger.EmptyLine()
 
 	consolelogger.Infof("%s(%+v)\n", w.functionName(input), w.functionParams(input))
@@ -70,6 +111,19 @@ func (w *WhenExpression) EvalFunction(input *gabs.Container) (bool, error) {
 	}
 
 	return changein.Eval(fun)
+}
+
+func (w *WhenExpression) EvaluateEnvFunction(input *gabs.Container) (string, error) {
+	consolelogger.EmptyLine()
+
+	consolelogger.Infof("%s(%+v)\n", w.functionName(input), w.functionParams(input))
+
+	fun, err := env.Parse(input)
+	if err != nil {
+		return "", err
+	}
+
+	return env.Eval(fun)
 }
 
 func (w *WhenExpression) functionName(input *gabs.Container) string {

--- a/test/e2e/env_simple.rb
+++ b/test/e2e/env_simple.rb
@@ -1,0 +1,88 @@
+# rubocop:disable all
+
+require_relative "../e2e"
+require 'yaml'
+
+pipeline = %q(
+version: v1.0
+name: Test
+agent:
+  machine:
+    type: e1-standard-2
+
+blocks:
+  - name: Test1
+    run:
+      when: "branch = 'master' or env('SEMAPHORE_GIT_PR_NAME') =~ '^docs:'"
+    task:
+      jobs:
+        - name: Hello
+          commands:
+            - echo "Hello World"
+
+  - name: Test2
+    run:
+      when: "branch = 'master' or env('SEMAPHORE_GIT_PR_NAME') =~ '^feature:'"
+    task:
+      jobs:
+        - name: Hello
+          commands:
+            - echo "Hello World"
+
+  - name: Test3
+    run:
+      when: "branch = 'master' or env('NON_EXISTENT_ENV_VAR') =~ '^feature:'"
+    task:
+      jobs:
+        - name: Hello
+          commands:
+            - echo "Hello World"
+)
+
+origin = TestRepoForChangeIn.setup()
+
+origin.add_file('.semaphore/semaphore.yml', pipeline)
+origin.commit!("Bootstrap")
+
+repo = origin.clone_local_copy(branch: "master")
+repo.run(%{
+  export SEMAPHORE_GIT_PR_NAME="docs: Change in deployment order"
+
+  #{spc} evaluate change-in --input .semaphore/semaphore.yml --output /tmp/output.yml --logs /tmp/logs.yml
+})
+
+assert_eq(YAML.load_file('/tmp/output.yml'), YAML.load(%{
+version: v1.0
+name: Test
+agent:
+  machine:
+    type: e1-standard-2
+
+blocks:
+  - name: Test1
+    run:
+      when: "(branch = 'master') or true"
+    task:
+      jobs:
+        - name: Hello
+          commands:
+            - echo "Hello World"
+
+  - name: Test2
+    run:
+      when: "(branch = 'master') or false"
+    task:
+      jobs:
+        - name: Hello
+          commands:
+            - echo "Hello World"
+
+  - name: Test3
+    run:
+      when: "(branch = 'master') or false"
+    task:
+      jobs:
+        - name: Hello
+          commands:
+            - echo "Hello World"
+}))

--- a/test/e2e/env_vars_in_docker_images.rb
+++ b/test/e2e/env_vars_in_docker_images.rb
@@ -1,0 +1,90 @@
+# rubocop:disable all
+
+require_relative "../e2e"
+require 'yaml'
+
+pipeline = %q(
+version: v1.0
+name: Test
+agent:
+  machine:
+    type: e1-standard-2
+
+blocks:
+  # Build docker image in a Linux VM
+
+  - name: Build
+    agent:
+      machine:
+        type: e1-standard-2
+    task:
+      jobs:
+        - name: Build
+          commands:
+            - make docker.build TAG=dev-env-$SEMAPHORE_GIT_COMMIT_SHA
+            - make docker.push
+
+  # Run tests in a Docker image
+
+  - name: Test
+    agent:
+      machine:
+        type: e1-standard-2
+      containers:
+        - name: main
+          image: "dev-env-$SEMAPHORE_GIT_COMMIT_SHA"
+    task:
+      jobs:
+        - name: Hello
+          commands:
+            - echo "Hello World"
+)
+
+origin = TestRepoForChangeIn.setup()
+
+origin.add_file('.semaphore/semaphore.yml', pipeline)
+origin.commit!("Bootstrap")
+
+repo = origin.clone_local_copy(branch: "master")
+repo.run(%{
+  export SEMAPHORE_GIT_COMMIT_SHA="055556799236d27ab754b503f2acad3e9a29350f"
+
+  #{spc} evaluate change-in --input .semaphore/semaphore.yml --output /tmp/output.yml --logs /tmp/logs.yml
+})
+
+assert_eq(YAML.load_file('/tmp/output.yml'), YAML.load(%{
+version: v1.0
+name: Test
+agent:
+  machine:
+    type: e1-standard-2
+
+blocks:
+  # Build docker image in a Linux VM
+
+  - name: Build
+    agent:
+      machine:
+        type: e1-standard-2
+    task:
+      jobs:
+        - name: Build
+          commands:
+            - make docker.build TAG=dev-env-$SEMAPHORE_GIT_COMMIT_SHA
+            - make docker.push
+
+  # Run tests in a Docker image
+
+  - name: Test
+    agent:
+      machine:
+        type: e1-standard-2
+      containers:
+        - name: main
+          image: "dev-env-055556799236d27ab754b503f2acad3e9a29350f"
+    task:
+      jobs:
+        - name: Hello
+          commands:
+            - echo "Hello World"
+}))

--- a/test/e2e/env_vars_in_docker_images.rb
+++ b/test/e2e/env_vars_in_docker_images.rb
@@ -9,6 +9,9 @@ name: Test
 agent:
   machine:
     type: e1-standard-2
+  containers:
+    - name: main
+      image: "dev-env-$SEMAPHORE_GIT_COMMIT_SHA"
 
 blocks:
   # Build docker image in a Linux VM
@@ -58,6 +61,9 @@ name: Test
 agent:
   machine:
     type: e1-standard-2
+  containers:
+    - name: main
+      image: "dev-env-055556799236d27ab754b503f2acad3e9a29350f"
 
 blocks:
   # Build docker image in a Linux VM


### PR DESCRIPTION
Allows for two things:

#### Case 1) Use environment variables to make decisions in change_in.

``` yaml
version: v1.0
name: Test
agent:
  machine:
    type: e1-standard-2

blocks:
  - name: Test1
    run:
      when: "branch = 'master' or env('SEMAPHORE_GIT_PR_NAME') =~ '^docs:'"
    task:
      jobs:
        - name: Hello
          commands:
            - echo "Hello World"

  - name: Test2
    run:
      when: "branch = 'master' or env('SEMAPHORE_GIT_PR_NAME') =~ '^feature:'"
    task:
      jobs:
        - name: Hello
          commands:
            - echo "Hello World"

  - name: Test3
    run:
      when: "branch = 'master' or env('NON_EXISTENT_ENV_VAR') =~ '^feature:'"
    task:
      jobs:
        - name: Hello
          commands:
            - echo "Hello World"
```

#### Case 2) Build a docker image in Block 1, use the Docker image in "compose style" in Block2, Block3, Block4.

``` yaml
version: v1.0
name: Test
agent:
  machine:
    type: e1-standard-2
    
blocks:
  # Build docker image in a Linux VM

  - name: Build
    agent:
      machine:
        type: e1-standard-2
    task:
      jobs:
        - name: Build
          commands:
            - make docker.build TAG=dev-env-$SEMAPHORE_GIT_COMMIT_SHA
            - make docker.push

  # Run tests in a Docker image

  - name: Test
    agent:
      machine:
        type: e1-standard-2
      containers:
        - name: main
          image: "dev-env-$SEMAPHORE_GIT_COMMIT_SHA"
    task:
      jobs:
        - name: Hello
          commands:
            - echo "Hello World"
```