### PR TITLE
Evaluate template expressions everywhere except in job commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/semaphoreci/spc
 go 1.21
 
 require (
+	github.com/42atomys/sprout v0.2.0
 	github.com/Jeffail/gabs/v2 v2.7.0
 	github.com/bmatcuk/doublestar/v4 v4.6.0
 	github.com/ghodss/yaml v1.0.0
@@ -12,7 +13,6 @@ require (
 
 require (
 	dario.cat/mergo v1.0.0 // indirect
-	github.com/42atomys/sprout v0.2.0 // indirect
 	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/bitfield/gotestdox v0.2.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/pkg/pipelines/template_evaluator.go
+++ b/pkg/pipelines/template_evaluator.go
@@ -42,184 +42,34 @@ func (e *templateEvaluator) Run() error {
 }
 
 func (e *templateEvaluator) ExtractAll() {
-	e.ExtractPipelineName()
-	e.ExtractFromQueue()
-	e.ExtractFromSecrets()
-	e.ExtractFromBlockNames()
-	e.ExtractFromJobNames()
-	e.ExtractFromAgents()
-	e.ExtractFromJobMatrices()
-	e.ExtractFromParallelisms()
+	e.ExtractTemplateExpression(e.pipeline.raw, []string{})
 }
 
-func (e *templateEvaluator) ExtractPipelineName() {
-	e.tryExtractingFromPath([]string{"name"})
-}
+func (e *templateEvaluator) ExtractTemplateExpression(parent *gabs.Container, parentPath []string){
+	path := []string{}
 
-func (e *templateEvaluator) ExtractFromQueue() {
-	e.tryExtractingFromPath([]string{"queue", "name"})
+	switch parent.Data().(type) {
 
-	for index := range e.pipeline.QueueRules() {
-		e.tryExtractingFromPath([]string{"queue", strconv.Itoa(index), "name"})
+		case []interface{}:
+			for childIndex, child := range parent.Children() {
+				path = concatPaths(parentPath, []string{strconv.Itoa(childIndex)})
+				e.ExtractTemplateExpression(child, path)
+			}
+
+		case map[string]interface{}:
+			for key, child := range parent.ChildrenMap() {
+				if key != "commands" {
+					path = concatPaths(parentPath, []string{key})
+					e.ExtractTemplateExpression(child, path)
+				}
+			}
+
+		default:
+			e.tryExtractingFromPath(parentPath)
 	}
 }
 
-func (e *templateEvaluator) ExtractFromSecrets() {
-	e.ExtractFromGlobalSecrets()
-	e.ExtractFromBlockSecrets()
-	e.ExtractFromAfterPipelineSecrets()
-}
-
-func (e *templateEvaluator) ExtractFromGlobalSecrets() {
-	e.extractFromSecretsAt(e.pipeline.GlobalJobConfig(), []string{"global_job_config"})
-}
-
-func (e *templateEvaluator) ExtractFromBlockSecrets() {
-	for blockIndex, block := range e.pipeline.Blocks() {
-		e.extractFromSecretsAt(block.Search("task"), []string{"blocks", strconv.Itoa(blockIndex), "task"})
-	}
-}
-
-func (e *templateEvaluator) ExtractFromAfterPipelineSecrets() {
-	e.extractFromSecretsAt(e.pipeline.AfterPipelineTask(), []string{"after_pipeline", "task"})
-}
-
-func (e *templateEvaluator) ExtractFromJobMatrices() {
-	e.ExtractFromBlockJobMatrices()
-	e.ExtractFromAfterPipelineJobMatrices()
-}
-
-func (e *templateEvaluator) ExtractFromBlockJobMatrices() {
-	for blockIndex, block := range e.pipeline.Blocks() {
-		blockTaskPath := []string{"blocks", strconv.Itoa(blockIndex), "task"}
-
-		for jobIndex, job := range block.Search("task", "jobs").Children() {
-			jobPath := concatPaths(blockTaskPath, []string{"jobs", strconv.Itoa(jobIndex)})
-			e.extractFromJobMatricesAt(job, jobPath)
-		}
-	}
-}
-
-func (e *templateEvaluator) ExtractFromAfterPipelineJobMatrices() {
-	afterPipelineTask := e.pipeline.AfterPipelineTask()
-
-	for jobIndex, job := range afterPipelineTask.Search("jobs").Children() {
-		jobPath := []string{"after_pipeline", "task", "jobs", strconv.Itoa(jobIndex)}
-		e.extractFromJobMatricesAt(job, jobPath)
-	}
-}
-
-func (e *templateEvaluator) ExtractFromParallelisms() {
-	e.ExtractFromBlockJobParallelisms()
-	e.ExtractFromAfterPipelineParallelisms()
-}
-
-func (e *templateEvaluator) ExtractFromBlockJobParallelisms() {
-	for blockIndex, block := range e.pipeline.Blocks() {
-		blockTaskPath := []string{"blocks", strconv.Itoa(blockIndex), "task"}
-
-		for jobIndex := range block.Search("task", "jobs").Children() {
-			jobPath := concatPaths(blockTaskPath, []string{"jobs", strconv.Itoa(jobIndex)})
-			e.tryExtractingFromPath(jobPath, []string{"parallelism"})
-		}
-	}
-}
-
-func (e *templateEvaluator) ExtractFromAfterPipelineParallelisms() {
-	afterPipelineTask := e.pipeline.AfterPipelineTask()
-
-	for jobIndex := range afterPipelineTask.Search("jobs").Children() {
-		jobPath := []string{"after_pipeline", "task", "jobs", strconv.Itoa(jobIndex)}
-		e.tryExtractingFromPath(jobPath, []string{"parallelism"})
-	}
-}
-
-func (e *templateEvaluator) ExtractFromAgents() {
-	e.ExtractFromTopLevelAgent()
-	e.ExtractFromBlockAgents()
-	e.ExtractFromAfterPipelineAgents()
-}
-
-func (e *templateEvaluator) ExtractFromTopLevelAgent() {
-	e.extractFromAgentAt(e.pipeline.Agent(), []string{"agent"})
-}
-
-func (e *templateEvaluator) ExtractFromBlockAgents() {
-	for blockIndex, block := range e.pipeline.Blocks() {
-		agent := block.Search("task", "agent")
-		agentPath := []string{"blocks", strconv.Itoa(blockIndex), "task", "agent"}
-		e.extractFromAgentAt(agent, agentPath)
-	}
-}
-
-func (e *templateEvaluator) ExtractFromAfterPipelineAgents() {
-	afterPipelineTask := e.pipeline.AfterPipelineTask()
-	if afterPipelineTask == nil {
-		return
-	}
-
-	e.extractFromAgentAt(afterPipelineTask, []string{"after_pipeline", "task"})
-}
-
-func (e *templateEvaluator) ExtractFromBlockNames() {
-	for blockIndex := range e.pipeline.Blocks() {
-		e.tryExtractingFromPath([]string{"blocks", strconv.Itoa(blockIndex), "name"})
-	}
-}
-
-func (e *templateEvaluator) ExtractFromJobNames() {
-	e.ExtractFromBlockJobNames()
-	e.ExtractFromAfterPipelineJobNames()
-}
-
-func (e *templateEvaluator) ExtractFromBlockJobNames() {
-	for blockIndex, block := range e.pipeline.Blocks() {
-		blockTaskPath := []string{"blocks", strconv.Itoa(blockIndex), "task"}
-		for jobIndex := range block.Search("task", "jobs").Children() {
-			e.tryExtractingFromPath(blockTaskPath, []string{"jobs", strconv.Itoa(jobIndex), "name"})
-		}
-	}
-}
-
-func (e *templateEvaluator) ExtractFromAfterPipelineJobNames() {
-	afterPipelineTask := e.pipeline.AfterPipelineTask()
-
-	for jobIndex := range afterPipelineTask.Search("jobs").Children() {
-		e.tryExtractingFromPath([]string{"after_pipeline", "task", "jobs", strconv.Itoa(jobIndex), "name"})
-	}
-}
-
-func (e *templateEvaluator) extractFromAgentAt(agent *gabs.Container, agentPath []string) {
-	e.tryExtractingFromPath(agentPath, []string{"machine", "type"})
-	e.tryExtractingFromPath(agentPath, []string{"machine", "os_image"})
-
-	for containerIndex, container := range agent.Search("containers").Children() {
-		containerPath := concatPaths(agentPath, []string{"containers", strconv.Itoa(containerIndex)})
-		e.extractFromContainerAt(container, containerPath)
-	}
-}
-
-func (e *templateEvaluator) extractFromContainerAt(container *gabs.Container, containerPath []string) {
-	e.tryExtractingFromPath(containerPath, []string{"name"})
-	e.tryExtractingFromPath(containerPath, []string{"image"})
-	e.extractFromSecretsAt(container, containerPath)
-}
-
-func (e *templateEvaluator) extractFromSecretsAt(parent *gabs.Container, parentPath []string) {
-	for secretIndex := range parent.Search("secrets").Children() {
-		e.tryExtractingFromPath(parentPath, []string{"secrets", strconv.Itoa(secretIndex), "name"})
-	}
-}
-
-func (e *templateEvaluator) extractFromJobMatricesAt(parent *gabs.Container, parentPath []string) {
-	for matrixIndex := range parent.Search("matrix").Children() {
-		e.tryExtractingFromPath(parentPath, []string{"matrix", strconv.Itoa(matrixIndex), "env_var"})
-		e.tryExtractingFromPath(parentPath, []string{"matrix", strconv.Itoa(matrixIndex), "values"})
-	}
-}
-
-func (e *templateEvaluator) tryExtractingFromPath(paths ...[]string) {
-	path := concatPaths(paths...)
+func (e *templateEvaluator) tryExtractingFromPath(path []string) {
 	if !e.pipeline.PathExists(path) {
 		return
 	}

--- a/test/e2e/parameters_and_change_in.rb
+++ b/test/e2e/parameters_and_change_in.rb
@@ -1,7 +1,7 @@
 # rubocop:disable all
 
 #
-# This test verifies that copiler can process all possible locations for both the
+# This test verifies that compiler can process all possible locations for both the
 # parameters and changs in the same yaml file.
 #
 
@@ -53,6 +53,7 @@ blocks:
         - name: Test
           commands:
             - make test
+            - echo "Template evaluation should not work here ${{parameters.DEPLOY_ENV}}"
           matrix:
             - env_var: "INTEGRATION_TEST"
               values: "%{{ \\"true,false\\" | splitList \\",\\" }}"
@@ -87,8 +88,15 @@ blocks:
 
 promotions:
   - name: Performance tests
+    pipeline_file: perf_test.yml
     auto_promote:
       when: "branch = 'master' and change_in('/lib')"
+  - name: Smoke tests on ${{parameters.DEPLOY_ENV}} env
+    pipeline_file: ${{parameters.DEPLOY_ENV}}_smoke_test.yml
+    parameters:
+      env_vars:
+        - name: ${{parameters.DEPLOY_ENV | upper}}_SERVICE_ID
+          default_value: ${{parameters.DEPLOY_ENV}}_${{parameters.SERVICE}}
 }
 
 origin = TestRepoForChangeIn.setup()
@@ -163,6 +171,7 @@ blocks:
         - name: Test
           commands:
             - make test
+            - echo "Template evaluation should not work here ${{parameters.DEPLOY_ENV}}"
           matrix: 
             - env_var: INTEGRATION_TEST
               values: ["true", "false"]
@@ -198,6 +207,13 @@ blocks:
 
 promotions:
   - name: Performance tests
+    pipeline_file: perf_test.yml
     auto_promote:
       when: "(branch = 'master') and true"
+  - name: Smoke tests on prod env
+    pipeline_file: prod_smoke_test.yml
+    parameters:
+      env_vars:
+        - name: PROD_SERVICE_ID
+          default_value: prod_web_server
 }))

--- a/test/fixtures/all_template_locations.yml
+++ b/test/fixtures/all_template_locations.yml
@@ -32,6 +32,7 @@ blocks:
         - name: Run tests
           commands:
             - echo "Running tests"
+            - echo "Template expressions are not evaluated here ${{parameters.SERVER}}"
           parallelism: "%{{parameters.PARALLELISM | mul 2}}"
 
   - name: Build and push image
@@ -66,4 +67,14 @@ after_pipeline:
       - name: Ping ${{parameters.DEPLOY_ENV}} from %{{parameters.PARALLELISM}} jobs
         commands:
           - echo "Pinging environment"
+          - echo "Template expressions are not evaluated here ${{parameters.SERVER}}"
         parallelism: "%{{parameters.PARALLELISM | int64 }}"
+
+promotions:
+  - name: Promotion to ${{parameters.DEPLOY_ENV}}
+    pipeline_file: ${{parameters.DEPLOY_ENV}}_deployment.yml
+    deployment_target: ${{parameters.DEPLOY_ENV}}_deployment_target
+    parameters:
+      env_vars:
+        - name: "${{parameters.DEPLOY_ENV | upper}}_SERVER_ID"
+          default_value: ${{parameters.SERVER}}


### PR DESCRIPTION
This PR changes how the SPC evaluates template expressions in yaml files.

Previously, we only checked if a specific set of fields in the pipeline yml file contained the template expressions.
This approach was taken initially to reduce the potential impact of introducing that new feature.
The main downside of this approach was that adding support for template expressions in new fields on a customer's request required a complicated release process where the SPC, toolbox, and customer's self-hosted agents needed to be updated.

With this new approach, we are going recursively through the whole pipeline yml file and checking every field for template expressions. This should eliminate the need for a complicated release process whenever a new use case appears.

The only potential issue with this approach is if some users use the same format as for our template expressions (e.g. for format: `${{ expr }}` or `%{{ expr }}`) for other reasons and that expression should not be evaluated by the SPC.

This is highly unlikely anywhere except in actual job commands and due to that, we excluded the `commands` field from the evaluation process.
In commands, you can access parameter values through environment variables and all other supported template functions have bash equivalents so excluding them from the evaluation process has no impact on usability.


