### PR TITLE
Correctly read commands from cmd file when file path is absolute

### DIFF
--- a/pkg/commands/file_test.go
+++ b/pkg/commands/file_test.go
@@ -18,7 +18,7 @@ func Test__Extract(t *testing.T) {
 
 	assert.Error(t, err)
 
-	expectedErrorMessage := "failed to open the commands_file at ../../test/fixtures/non_existing_file.txt"
+	expectedErrorMessage := "failed to open the commands_file at"
 	assert.Contains(t, err.Error(), expectedErrorMessage)
 
 	// If commands file is empty, it retruns the error
@@ -27,15 +27,23 @@ func Test__Extract(t *testing.T) {
 
 	assert.Error(t, err)
 
-	expectedErrorMessage = "the commands_file at location ../../test/fixtures/empty_file.txt is empty"
+	expectedErrorMessage = "empty_file.txt is empty"
 	assert.Contains(t, err.Error(), expectedErrorMessage)
 
-	// Commands are read successfully from the valid file.
+	// Commands are read successfully from the valid file with relative path.
 	file.FilePath = "valid_commands_file.txt"
 	err = file.Extract()
 	
 	assert.Nil(t, err)
 
 	expectedCommands := []string{"echo 1", "echo 12", "echo 123"}
+	assert.Equal(t, file.Commands, expectedCommands)
+
+	// Commands are read successfully from the valid file with absolute path.
+	file.FilePath = "/../../test/fixtures/valid_commands_file.txt"
+	file.Commands = []string{}
+	err = file.Extract()
+	
+	assert.Nil(t, err)
 	assert.Equal(t, file.Commands, expectedCommands)
 }

--- a/test/e2e/cmd_files_all_possible_locations.rb
+++ b/test/e2e/cmd_files_all_possible_locations.rb
@@ -17,7 +17,7 @@ agent:
     os_image: "ubuntu2004"
 global_job_config:
   prologue:
-    commands_file: "valid_commands_file.txt"
+    commands_file: "/.semaphore/valid_commands_file.txt"
   epilogue:
     always:
       commands_file: "valid_commands_file.txt"
@@ -36,7 +36,7 @@ blocks:
         on_pass:
           commands_file: "valid_commands_file.txt"
         on_fail:
-          commands_file: "valid_commands_file.txt"
+          commands_file: "/.semaphore/valid_commands_file.txt"
       jobs:
         - name: Run tests
           commands_file: "valid_commands_file.txt"


### PR DESCRIPTION
https://github.com/renderedtext/tasks/issues/6869

This fixes support for specifying the commands_file location with an absolute path (relative to the root of the git repository) rather than a relative path (relative to the location of the YAML file where the commands_file is used).
