### PR TITLE
Fix misc typos

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -22,13 +22,9 @@ blocks:
   - name: "Security checks"
     dependencies: []
     task:
-      secrets:
-        - name: security-toolbox-shared-read-access
       prologue:
         commands:
           - checkout
-          - mv ~/.ssh/security-toolbox ~/.ssh/id_rsa
-          - sudo chmod 600 ~/.ssh/id_rsa
       jobs:
         - name: Check dependencies
           commands:

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,17 @@
 .PHONY: build test
 
 SECURITY_TOOLBOX_BRANCH ?= master
-SECURITY_TOOLBOX_TMP_DIR ?= /tmp/security-toolbox
+MONOREPO_TMP_DIR?=/tmp/monorepo
+SECURITY_TOOLBOX_TMP_DIR?=$(MONOREPO_TMP_DIR)/security-toolbox
 
 check.prepare:
-	rm -rf $(SECURITY_TOOLBOX_TMP_DIR)
-	git clone git@github.com:renderedtext/security-toolbox.git $(SECURITY_TOOLBOX_TMP_DIR) && (cd $(SECURITY_TOOLBOX_TMP_DIR) && git checkout $(SECURITY_TOOLBOX_BRANCH) && cd -)
+	rm -rf $(MONOREPO_TMP_DIR)
+	git clone --depth 1 --filter=blob:none --sparse https://github.com/semaphoreio/semaphore $(MONOREPO_TMP_DIR) && \
+		cd $(MONOREPO_TMP_DIR) && \
+		git config core.sparseCheckout true && \
+		git sparse-checkout init --cone && \
+		git sparse-checkout set security-toolbox && \
+		git checkout main && cd -
 
 check.static: check.prepare
 	docker run -it -v $$(pwd):/app \

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Tooling for compiling and evaluating pipelines on Semaphore 2.0.
 
 # Release Process
 
-Releases are built by Sempahore for every git tag on Github. To initialize the
+Releases are built by Semaphore for every git tag on GitHub. To initialize the
 release process:
 
 1. go to the project root
-2. Run `make tag.patch` (or `make tag.minor`, or `make tag.major`) to bump and push a new tag to Github
+2. Run `make tag.patch` (or `make tag.minor`, or `make tag.major`) to bump and push a new tag to GitHub
 3. Semaphore will take over, and execute the `.semaphore/release.yml`.
 
-On Sempahore, we use GoReleaser to create releases. Its configuration is stored
+On Semaphore, we use GoReleaser to create releases. Its configuration is stored
 in `.goreleaser.yml`.

--- a/pkg/commands/file.go
+++ b/pkg/commands/file.go
@@ -16,7 +16,7 @@ type File struct {
 }
 
 func (f *File) Extract() error {
-	// Get the full path to the commands file in the reposiotry
+	// Get the full path to the commands file in the repository
 	absoluteFilePath, err := f.getAbsoluteFilePath()
 	if err != nil {
 		return fmt.Errorf("failed to resolved the file path for file %s, error: %w", absoluteFilePath, err)

--- a/pkg/commands/file_test.go
+++ b/pkg/commands/file_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func Test__Extract(t *testing.T) {
-	// If commands file does not exist, it retruns the error
+	// If commands file does not exist, it returns the error
 	file := File{
 		FilePath:   "non_existing_file.txt",
 		ParentPath: []string{},
@@ -21,7 +21,7 @@ func Test__Extract(t *testing.T) {
 	expectedErrorMessage := "failed to open the commands_file at"
 	assert.Contains(t, err.Error(), expectedErrorMessage)
 
-	// If commands file is empty, it retruns the error
+	// If commands file is empty, it returns the error
 	file.FilePath = "empty_file.txt"
 	err = file.Extract()
 

--- a/pkg/pipelines/when_evaluator.go
+++ b/pkg/pipelines/when_evaluator.go
@@ -120,18 +120,18 @@ func (e *whenEvaluator) parse() error {
 		expressions = append(expressions, e.Expression)
 	}
 
-	requirments, err := whencli.ListInputs(expressions)
+	requirements, err := whencli.ListInputs(expressions)
 	if err != nil {
 		return err
 	}
 
-	err = e.verifyParsed(requirments)
+	err = e.verifyParsed(requirements)
 	if err != nil {
 		return err
 	}
 
 	for index := range e.list {
-		e.list[index].Requirments = requirments[index].Inputs
+		e.list[index].Requirements = requirements[index].Inputs
 	}
 
 	return nil
@@ -151,10 +151,10 @@ func (e *whenEvaluator) displayFound() {
 	}
 }
 
-func (e *whenEvaluator) verifyParsed(requirments []whencli.ListInputsResult) error {
+func (e *whenEvaluator) verifyParsed(requirements []whencli.ListInputsResult) error {
 	var err error
 
-	for index, r := range requirments {
+	for index, r := range requirements {
 		if r.Error != "" {
 			loc := logs.Location{
 				Path: e.list[index].Path,

--- a/pkg/when/changein/function.go
+++ b/pkg/when/changein/function.go
@@ -82,7 +82,7 @@ func (f *Function) IsPatternMatchWith(diffLine string) bool {
 		return true
 	}
 
-	if _, ok := f.IsPatternMacthed(diffLine); ok {
+	if _, ok := f.IsPatternMatched(diffLine); ok {
 		return true
 	}
 
@@ -99,7 +99,7 @@ func (f *Function) IsDiffLineExcluded(diffLine string) (string, bool) {
 	return "", false
 }
 
-func (f *Function) IsPatternMacthed(diffLine string) (string, bool) {
+func (f *Function) IsPatternMatched(diffLine string) (string, bool) {
 	for _, pathPattern := range f.PathPatterns {
 		if patternMatch(diffLine, pathPattern, f.Workdir) {
 			return pathPattern, true

--- a/pkg/when/changein/parser.go
+++ b/pkg/when/changein/parser.go
@@ -74,7 +74,7 @@ func (p *parser) PathPatterns() ([]string, error) {
 
 	result, ok := p.castToStringArray(firstArg.Data())
 	if !ok {
-		return []string{}, fmt.Errorf("uprocessable path parameter in change in expression")
+		return []string{}, fmt.Errorf("unprocessable path parameter in change in expression")
 	}
 
 	return result, nil
@@ -117,7 +117,7 @@ func (p *parser) ExcludedPathPatterns() ([]string, error) {
 
 	result, ok := p.castToStringArray(excludedPaths)
 	if !ok {
-		return []string{}, fmt.Errorf("uprocessable exclude path parameter in change in expression")
+		return []string{}, fmt.Errorf("unprocessable exclude path parameter in change in expression")
 	}
 
 	return result, nil

--- a/pkg/when/expression.go
+++ b/pkg/when/expression.go
@@ -11,20 +11,20 @@ type WhenExpression struct {
 	Expression   string
 	Path         []string
 	YamlPath     string
-	Requirments  *gabs.Container
+	Requirements  *gabs.Container
 	ReduceInputs whencli.ReduceInputs
 }
 
 func (w *WhenExpression) Eval() error {
-	for _, requirment := range w.ListChangeInFunctions(w.Requirments) {
-		result, err := w.EvalFunction(requirment)
+	for _, requirement := range w.ListChangeInFunctions(w.Requirements) {
+		result, err := w.EvalFunction(requirement)
 		if err != nil {
 			return err
 		}
 
 		input := map[string]interface{}{}
-		input["name"] = w.functionName(requirment)
-		input["params"] = w.functionParams(requirment)
+		input["name"] = w.functionName(requirement)
+		input["params"] = w.functionParams(requirement)
 		input["result"] = result
 
 		w.ReduceInputs.Keywords = map[string]interface{}{}
@@ -34,10 +34,10 @@ func (w *WhenExpression) Eval() error {
 	return nil
 }
 
-func (w *WhenExpression) ListChangeInFunctions(requirments *gabs.Container) []*gabs.Container {
+func (w *WhenExpression) ListChangeInFunctions(requirements *gabs.Container) []*gabs.Container {
 	result := []*gabs.Container{}
 
-	for _, input := range requirments.Children() {
+	for _, input := range requirements.Children() {
 		if w.IsChangeInFunction(input) {
 			result = append(result, input)
 		}

--- a/pkg/when/whencli/list_inputs.go
+++ b/pkg/when/whencli/list_inputs.go
@@ -31,7 +31,7 @@ func ListInputs(expressions []string) ([]ListInputsResult, error) {
 
 	output, err := exec.Command("when", "list-inputs", "--input", inputPath, "--output", outputPath).CombinedOutput()
 	if err != nil {
-		return res, fmt.Errorf("unprecessable when expressions %s", string(output))
+		return res, fmt.Errorf("unprocessable when expressions %s", string(output))
 	}
 
 	results, err := ListInputsLoadResults(outputPath)

--- a/test/e2e/change_in_excluded_paths.rb
+++ b/test/e2e/change_in_excluded_paths.rb
@@ -24,8 +24,8 @@ require 'yaml'
 #   change_in('/client')
 #
 # But for the backend, it is trickier. We want the block to run if there are any
-# changes in the repository, except if those changes are comming from the client
-# directory. To codify this exlusion, the exclude list can be used:
+# changes in the repository, except if those changes are coming from the client
+# directory. To codify this exclusion, the exclude list can be used:
 #
 #   change_in('/', {exclude: ['/client']})
 #

--- a/test/e2e/change_in_on_forked_prs.rb
+++ b/test/e2e/change_in_on_forked_prs.rb
@@ -1,10 +1,10 @@
 # rubocop:disable all
 
 #
-# This is not a full e2e test since it is impossible to completely immitate
+# This is not a full e2e test since it is impossible to completely imitate
 # forked pull requests without GitHub.
 # Instead, this tests replicates approach from test in *change_in_on_prs.rb*
-# for testing regullar PRs but has several enivronment variables set in a way
+# for testing regular PRs but has several environment variables set in a way
 # to indicate to change_in that it is a forked PR and that it should use a value
 # of SEMAPHORE_GIT_COMMIT_RANGE env var as a range for git diff.
 #

--- a/test/e2e/change_in_on_non_master_prs.rb
+++ b/test/e2e/change_in_on_non_master_prs.rb
@@ -10,7 +10,7 @@
 # - we need to fetch both the target and the PR branch
 #
 # This test simulates this state by creating repo with two non-master branches,
-# merging them and reseting HEAD of target branch back by one so merge commit
+# merging them and resetting HEAD of target branch back by one so merge commit
 # becomes a detached head when it is checked out and then deleting the target
 # branch.
 #

--- a/test/e2e/change_in_on_prs.rb
+++ b/test/e2e/change_in_on_prs.rb
@@ -13,7 +13,7 @@
 # after the source branch diverged.
 #
 # This test simulates this state by creating repo with two branches, merging
-# them and reseting HEAD of target branch back by one so merge commit becomes
+# them and resetting HEAD of target branch back by one so merge commit becomes
 # a detached head when it is checked out.
 #
 

--- a/test/e2e/parameters_and_change_in.rb
+++ b/test/e2e/parameters_and_change_in.rb
@@ -2,7 +2,7 @@
 
 #
 # This test verifies that compiler can process all possible locations for both the
-# parameters and changs in the same yaml file.
+# parameters and changes in the same yaml file.
 #
 
 require_relative "../e2e"


### PR DESCRIPTION
Ended up reading through the repo since I was having issues with `change_in`, it was an issue on my end since I didn't realise that all jobs will run if the files change, so read through [`changein/function.go`](https://github.com/semaphoreci/spc/blob/master/pkg/when/changein/function.go) and nosey me sees a typo, so trawled through and addressed them.

Nothing major, just internal changes, docs improvements, error messages made clearer.