### PR TITLE
ci: migrate semaphore YAMLs to use Ubuntu 24.04

### DIFF
--- a/.semaphore/release.yml
+++ b/.semaphore/release.yml
@@ -2,8 +2,8 @@ version: "v1.0"
 name: "Github Release"
 agent:
   machine:
-    type: e2-standard-2
-    os_image: ubuntu2004
+    type: f1-standard-2
+    os_image: ubuntu2404
 blocks:
   - name: "Github Release"
     task:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -2,8 +2,8 @@ version: v1.0
 name: Go
 agent:
   machine:
-    type: e2-standard-2
-    os_image: ubuntu2004
+    type: f1-standard-2
+    os_image: ubuntu2404
 
 global_job_config:
   prologue:


### PR DESCRIPTION
Migrate Semaphore to use Ubuntu 24.04 and `f1-standard` machines.

More details in [the task](https://github.com/renderedtext/project-tasks/issues/3087).