### PR TITLE
ci(release): use github-release-bot-spc secret for GitHub release

### DIFF
--- a/.semaphore/release.yml
+++ b/.semaphore/release.yml
@@ -11,7 +11,7 @@ blocks:
         - name: GO111MODULE
           value: "on"
       secrets:
-        - name: release-token
+        - name: github-release-bot-spc
       prologue:
         commands:
           - sem-version go 1.21


### PR DESCRIPTION
## What

Switch the GoReleaser release block in `.semaphore/release.yml` from the `release-token` secret to `github-release-bot-spc`.

## Why

Aligns the release pipeline with the dedicated release-bot secret used for publishing GitHub releases.

## Note

The `github-release-bot-spc` secret must exist in the org (carrying the GitHub token GoReleaser uses) before the next tag release, otherwise the `Release on Github` promotion will fail. Change is config-only; the release pipeline runs only on tag push (`^refs/tags/v*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)